### PR TITLE
App lock + shortcut recorder (v0.3.0)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
-            libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libhunspell-dev patchelf
+            libxdo-dev libdbus-1-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libhunspell-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
-            libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libhunspell-dev patchelf
+            libxdo-dev libdbus-1-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libhunspell-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Why whatRust? A lean, native WhatsApp Desktop alternative](#why-whatrust-a-lean-native-whatsapp-desktop-alternative)
 - [Features](#features)
 - [Run multiple WhatsApp accounts](#run-multiple-whatsapp-accounts)
+- [Lock the app (optional)](#lock-the-app-optional)
 - [whatRust vs the official WhatsApp Desktop (Electron)](#whatrust-vs-the-official-whatsapp-desktop-electron)
 - [Requirements](#requirements)
 - [Installation](#installation)
@@ -47,6 +48,7 @@ The official WhatsApp Desktop app is built on Electron, which packs an entire Ch
 ## Features
 
 - **Multiple WhatsApp accounts** — run several numbers at once, each in its own window with a fully isolated login (add, rename, and remove accounts)
+- **Optional app lock** — password (Argon2id) or biometric (Windows Hello / Touch ID / Linux polkit); locks on launch, on demand, on hide-to-tray, or after idle
 - **System tray** icon with **close-to-tray** and an **unread message badge**
 - **Native OS notifications** for new messages
 - **Persistent login** — scan the QR code once, stay signed in across restarts
@@ -68,6 +70,25 @@ whatRust runs **multiple WhatsApp accounts at the same time** — each account o
 
 > **macOS note:** running **multiple accounts requires macOS 14 (Sonoma) or later**, where the system webview supports isolated data stores. On macOS 12–13 whatRust runs a single account. Linux and Windows have no such limit.
 
+## Lock the app (optional)
+
+whatRust can require a password — or a fingerprint / Windows Hello / Touch ID where your
+OS supports it — before showing your chats. Enable it under **Settings → Security**.
+
+- **Password** works on every platform (Argon2id, stored locally).
+- **Biometric** is an optional shortcut: Windows Hello on Windows, Touch ID on any Mac
+  that has it, and the system fingerprint dialog on Linux where polkit/`pam_fprintd` is
+  configured (native `.deb` install only; the AppImage falls back to the password).
+- Lock **on launch**, **on demand** (tray → *Lock now*), **when hidden to the tray**, or
+  **after an idle timeout** — each toggleable in Settings.
+- Forgot your password? **Reset** from the lock screen logs out all accounts and clears
+  the lock (you'll re-scan the QR). There is no backdoor.
+
+> **What the lock does and doesn't do:** it controls who can open whatRust's windows. It
+> does **not** encrypt your data on disk — your WhatsApp session stays readable to other
+> software running as your user, locked or not (the same posture as Signal Desktop). For
+> at-rest protection, use full-disk encryption (FileVault / BitLocker / LUKS).
+
 ## whatRust vs the official WhatsApp Desktop (Electron)
 
 | Feature | whatRust | Official WhatsApp Desktop (Electron) |
@@ -84,6 +105,7 @@ whatRust runs **multiple WhatsApp accounts at the same time** — each account o
 | Native notifications | ✅ Yes | ✅ Yes |
 | Voice messages & calls (mic/camera) | ✅ Yes | ✅ Yes |
 | Multiple accounts (isolated sessions) | ✅ Yes | ❌ No |
+| Optional app lock (password + biometric) | ✅ Yes | ❌ No |
 | Global show/hide shortcut | ✅ Yes | ❌ No |
 | Launch at startup | ✅ Yes | ✅ Yes |
 | Affiliated with Meta | ❌ No (unofficial) | ✅ Yes |
@@ -163,6 +185,10 @@ Yes. whatRust grants the webview microphone and camera access, so voice messages
 
 ### Can I use multiple WhatsApp accounts in whatRust?
 Yes. whatRust supports **multiple WhatsApp accounts** running at the same time — each opens in its own window with a fully isolated session, so different numbers stay logged in independently. Add, rename, and remove accounts from **Settings → Accounts**. On macOS this requires macOS 14 or later; Linux and Windows have no limit.
+
+### Does whatRust have an app lock?
+
+Yes. You can set a password under **Settings → Security** to require authentication before whatRust shows your chats. Biometric unlock (Windows Hello, Touch ID, or Linux polkit with an enrolled fingerprint) is an optional shortcut where the OS supports it. The lock controls window access — it does not encrypt data on disk (same posture as Signal Desktop). For at-rest protection use full-disk encryption.
 
 ### Does whatRust support the system tray and close-to-tray?
 Yes. It adds a system tray icon with an unread-message badge, can close to the tray, and forwards new messages to native OS notifications.

--- a/docs/superpowers/plans/2026-06-01-app-lock.md
+++ b/docs/superpowers/plans/2026-06-01-app-lock.md
@@ -1,0 +1,1747 @@
+# whatRust App Lock — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional app lock to whatRust — an Argon2id password (all platforms) plus optional biometric unlock (Windows Hello / macOS Touch ID / Linux polkit) — that gates every account window.
+
+**Architecture:** A `LockState { unlocked, hidden }` managed state is the source of truth. Locking hides all `wa-*`/`settings` windows and shows a dedicated `lock` window; unlocking restores them. The real security boundary is in-command `require_unlocked` / `is_lock_window` guards (Tauri v2 does not authorize app commands per-window — same reason the repo already uses `is_remote`). Biometric is a per-platform native module behind one trait; the password is always the fallback. Access-control only — not encryption at rest.
+
+**Tech Stack:** Rust + Tauri v2 (2.11.2), `argon2` 0.5.3, `windows` 0.61 (Hello), `objc2-local-authentication` 0.3.2 (Touch ID), `zbus`/`zbus_polkit` 5 (polkit), `user-idle` (idle trigger). Vanilla JS settings/lock UIs.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-app-lock-design.md`
+
+**Working directory:** all `cargo` commands run from `src-tauri/`. The test runner is `cargo test --lib`.
+
+> **De-risk pass applied (2026-06-01):** the load-bearing native-API code in this plan
+> was verified against the resolved crate versions by a 6-way verification workflow.
+> Four compile blockers were found and already folded in: (A) `IUserConsentVerifierInterop`
+> import path, (B) `windows` Cargo features, (C) Linux must use `AuthorityProxyBlocking`
+> (not the async proxy), (D) polkit needs a `Box<dyn Error>` unifying type. Version pins:
+> `windows`/`windows-core` 0.61 (match Tauri — do NOT bump to 0.62), `argon2` 0.5.3
+> default features ON, `objc2`/`block2` 0.6.x, `objc2-local-authentication` 0.3.2 with
+> `["LAContext","block2"]`, `zbus`/`zbus_polkit` 5 (blocking API), `user-idle` 0.6.0
+> (X11/XWayland only). Items still needing real Windows/macOS hardware are flagged inline.
+
+---
+
+### Task 1: `applock.rs` — config + Argon2 password hashing
+
+**Files:**
+- Create: `src-tauri/src/applock.rs`
+- Modify: `src-tauri/Cargo.toml` (add `argon2`)
+- Modify: `src-tauri/src/lib.rs:1-7` (add `mod applock;`)
+
+- [ ] **Step 1: Add the dependency**
+
+In `src-tauri/Cargo.toml`, under `[dependencies]` (after `serde_json = "1"`):
+
+```toml
+argon2 = "0.5.3"  # Argon2id password hashing for the app lock (PHC strings)
+```
+
+**Do NOT set `default-features = false`** — the default set (`alloc`, `password-hash`,
+`rand`) is exactly what provides `OsRng`, `SaltString::generate`, and `hash_password`.
+Disabling defaults breaks the whole snippet. (Verified: the code below compiles on
+default features with no extra flags.)
+
+- [ ] **Step 2: Declare the module**
+
+In `src-tauri/src/lib.rs`, add to the module list at the top (after `mod accounts;`):
+
+```rust
+mod applock;
+```
+
+- [ ] **Step 3: Write `applock.rs` with failing tests**
+
+Create `src-tauri/src/applock.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+/// Persisted app-lock configuration. Stored in its own `app-lock.json` (NOT in
+/// settings.json) so the password hash never rides along with the general settings
+/// blob and is never serialized to the frontend.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AppLockConfig {
+    pub enabled: bool,
+    /// Argon2id PHC string (salt embedded). `None` when the lock is disabled.
+    pub password_phc: Option<String>,
+    pub biometric_enabled: bool,
+    pub lock_on_launch: bool,
+    pub lock_on_hide: bool,
+    /// Idle auto-lock threshold in seconds. 0 == off.
+    pub idle_secs: u32,
+}
+
+impl Default for AppLockConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            password_phc: None,
+            biometric_enabled: false,
+            lock_on_launch: true,
+            lock_on_hide: false,
+            idle_secs: 0,
+        }
+    }
+}
+
+impl AppLockConfig {
+    /// The lock is only truly active when it is enabled AND a password exists. A
+    /// bare `enabled` with no hash can never lock the user out.
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.password_phc.is_some()
+    }
+}
+
+fn config_path(app: &AppHandle) -> tauri::Result<PathBuf> {
+    let dir = app.path().app_config_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir.join("app-lock.json"))
+}
+
+pub fn load(app: &AppHandle) -> AppLockConfig {
+    config_path(app)
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+pub fn save(app: &AppHandle, c: &AppLockConfig) -> tauri::Result<()> {
+    let path = config_path(app)?;
+    let json = serde_json::to_string_pretty(c).expect("serialize app-lock config");
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Hash a passcode into an Argon2id PHC string. `Argon2::default()` is Argon2id,
+/// version 0x13, with OWASP-baseline parameters. The random salt is embedded in the
+/// returned PHC string, so nothing else needs storing.
+pub fn hash_password(password: &str) -> Result<String, String> {
+    use argon2::password_hash::{rand_core::OsRng, PasswordHasher, SaltString};
+    use argon2::Argon2;
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| e.to_string())
+}
+
+/// Verify a passcode against a stored PHC string. Returns false on any parse/verify
+/// error (never panics, never leaks which step failed).
+pub fn verify_password(password: &str, phc: &str) -> bool {
+    use argon2::password_hash::{PasswordHash, PasswordVerifier};
+    use argon2::Argon2;
+    match PasswordHash::new(phc) {
+        Ok(parsed) => Argon2::default()
+            .verify_password(password.as_bytes(), &parsed)
+            .is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_sane() {
+        let c = AppLockConfig::default();
+        assert!(!c.enabled);
+        assert!(c.password_phc.is_none());
+        assert!(!c.biometric_enabled);
+        assert!(c.lock_on_launch);
+        assert!(!c.lock_on_hide); // user decision: hide-to-tray lock ships OFF
+        assert_eq!(c.idle_secs, 0);
+    }
+
+    #[test]
+    fn is_active_requires_enabled_and_hash() {
+        let mut c = AppLockConfig::default();
+        assert!(!c.is_active());
+        c.enabled = true;
+        assert!(!c.is_active(), "enabled without a hash must not be active");
+        c.password_phc = Some("x".into());
+        assert!(c.is_active());
+    }
+
+    #[test]
+    fn partial_json_fills_defaults() {
+        let c: AppLockConfig = serde_json::from_str(r#"{"enabled": true}"#).unwrap();
+        assert!(c.enabled);
+        assert!(c.lock_on_launch);
+        assert!(!c.lock_on_hide);
+        assert_eq!(c.idle_secs, 0);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let c = AppLockConfig { enabled: true, idle_secs: 300, ..Default::default() };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: AppLockConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn hash_then_verify_roundtrips() {
+        let phc = hash_password("correct horse").unwrap();
+        assert!(phc.starts_with("$argon2id$"), "must be Argon2id: {phc}");
+        assert!(verify_password("correct horse", &phc));
+    }
+
+    #[test]
+    fn wrong_password_fails() {
+        let phc = hash_password("secret").unwrap();
+        assert!(!verify_password("nope", &phc));
+    }
+
+    #[test]
+    fn verify_rejects_garbage_phc() {
+        assert!(!verify_password("anything", "not-a-phc-string"));
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests (expect they pass once it compiles)**
+
+Run: `cd src-tauri && cargo test --lib applock::`
+Expected: 6 tests pass. If `OsRng` is not found, add the `rand` feature: `argon2 = { version = "0.5.3", features = ["rand"] }` (it is on by default, so this should not be needed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/applock.rs src-tauri/src/lib.rs src-tauri/Cargo.toml src-tauri/Cargo.lock
+git commit -m "feat(applock): config struct + Argon2id password hashing"
+```
+
+---
+
+### Task 2: `lock.rs` — LockState, lock/unlock, lock window
+
+**Files:**
+- Create: `src-tauri/src/lock.rs`
+- Modify: `src-tauri/src/lib.rs:1-7` (add `mod lock;`)
+
+- [ ] **Step 1: Declare the module**
+
+In `src-tauri/src/lib.rs` module list, add:
+
+```rust
+mod lock;
+```
+
+- [ ] **Step 2: Write `lock.rs` with the pure-helper tests**
+
+Create `src-tauri/src/lock.rs`:
+
+```rust
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// Runtime lock state. `unlocked == false` means the app is locked.
+pub struct LockState {
+    pub unlocked: Mutex<bool>,
+    /// Labels of windows hidden by `lock_now`, to re-show on `unlock`.
+    pub hidden: Mutex<Vec<String>>,
+}
+
+impl LockState {
+    pub fn new(unlocked: bool) -> Self {
+        Self {
+            unlocked: Mutex::new(unlocked),
+            hidden: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+/// Whether a window label should be hidden behind the lock screen. Pure, unit-tested.
+/// The lock window itself is never hidden; everything user-facing (`wa-*` + settings) is.
+pub fn should_hide(label: &str) -> bool {
+    label != "lock" && (label.starts_with("wa-") || label == "settings")
+}
+
+/// Pure predicate behind the lock-window IPC guard.
+pub fn is_lock_label(label: &str) -> bool {
+    label == "lock"
+}
+
+pub fn is_lock_window(window: &tauri::Window) -> bool {
+    is_lock_label(window.label())
+}
+
+/// Read the current unlocked flag. Defaults to `true` (unlocked) when the state is
+/// not yet managed, so nothing is accidentally gated before setup runs.
+pub fn is_unlocked(app: &AppHandle) -> bool {
+    app.try_state::<LockState>()
+        .map(|s| *s.unlocked.lock().unwrap())
+        .unwrap_or(true)
+}
+
+/// IPC guard for sensitive commands.
+pub fn require_unlocked(app: &AppHandle) -> Result<(), String> {
+    if is_unlocked(app) {
+        Ok(())
+    } else {
+        Err("locked".into())
+    }
+}
+
+/// Lock the app: mark locked, hide every user-facing window (recording which were
+/// visible), and show the lock screen.
+pub fn lock_now(app: &AppHandle) {
+    if let Some(state) = app.try_state::<LockState>() {
+        *state.unlocked.lock().unwrap() = false;
+    }
+    let mut hidden = Vec::new();
+    for (label, w) in app.webview_windows() {
+        if should_hide(&label) && w.is_visible().unwrap_or(false) {
+            let _ = w.hide();
+            hidden.push(label);
+        }
+    }
+    if let Some(state) = app.try_state::<LockState>() {
+        *state.hidden.lock().unwrap() = hidden;
+    }
+    show_lock_window(app);
+}
+
+/// Unlock the app: mark unlocked, destroy the lock window, and restore the windows
+/// that were visible when we locked (or fall back to the active account).
+pub fn unlock(app: &AppHandle) {
+    if let Some(state) = app.try_state::<LockState>() {
+        *state.unlocked.lock().unwrap() = true;
+    }
+    if let Some(w) = app.get_webview_window("lock") {
+        let _ = w.destroy();
+    }
+    let hidden = app
+        .try_state::<LockState>()
+        .map(|s| std::mem::take(&mut *s.hidden.lock().unwrap()))
+        .unwrap_or_default();
+    if hidden.is_empty() {
+        crate::window::show_active(app);
+    } else {
+        for label in hidden {
+            crate::window::show_account(app, &label);
+        }
+    }
+}
+
+/// Create-or-show the dedicated lock window. `content_protected` blocks screen
+/// capture of the lock screen; `prevent_close` while locked stops the X from
+/// relaunching into an unlocked state.
+pub fn show_lock_window(app: &AppHandle) {
+    if let Some(w) = app.get_webview_window("lock") {
+        let _ = w.show();
+        let _ = w.set_focus();
+        return;
+    }
+    let built = WebviewWindowBuilder::new(app, "lock", WebviewUrl::App("lock.html".into()))
+        .title("whatRust — Locked")
+        .inner_size(420.0, 540.0)
+        .resizable(false)
+        .decorations(false)
+        .always_on_top(true)
+        .content_protected(true)
+        .center()
+        .focused(true)
+        .build();
+
+    if let Ok(win) = built {
+        let app_handle = app.clone();
+        win.on_window_event(move |event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                if !is_unlocked(&app_handle) {
+                    api.prevent_close();
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_hide_covers_accounts_and_settings() {
+        assert!(should_hide("wa-default"));
+        assert!(should_hide("wa-acct-3"));
+        assert!(should_hide("settings"));
+    }
+
+    #[test]
+    fn should_hide_never_hides_the_lock_window() {
+        assert!(!should_hide("lock"));
+    }
+
+    #[test]
+    fn is_lock_label_matches_only_lock() {
+        assert!(is_lock_label("lock"));
+        assert!(!is_lock_label("settings"));
+        assert!(!is_lock_label("wa-default"));
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cd src-tauri && cargo test --lib lock::`
+Expected: 3 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/lock.rs src-tauri/src/lib.rs
+git commit -m "feat(applock): LockState + lock/unlock + dedicated lock window"
+```
+
+---
+
+### Task 3: Lock-window capability + lock screen UI (password-only)
+
+**Files:**
+- Create: `src-tauri/capabilities/lock.json`
+- Create: `settings-ui/lock.html`
+- Create: `settings-ui/lock.js`
+- Create: `settings-ui/lock.css`
+
+- [ ] **Step 1: Add the capability**
+
+Create `src-tauri/capabilities/lock.json`:
+
+```json
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "lock-local",
+  "description": "IPC for the app-lock screen. core:default for invoke; no remote, no account/notification permissions. Per-command authorization is enforced in Rust (is_lock_window).",
+  "windows": ["lock"],
+  "permissions": ["core:default"]
+}
+```
+
+- [ ] **Step 2: Create the lock screen markup**
+
+Create `settings-ui/lock.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>whatRust — Locked</title>
+    <link rel="stylesheet" href="lock.css" />
+  </head>
+  <body>
+    <div class="lock-card">
+      <div class="lock-glyph" aria-hidden="true">🔒</div>
+      <h1>whatRust is locked</h1>
+      <input type="password" id="password" placeholder="Password" autocomplete="current-password" />
+      <button id="unlock">Unlock</button>
+      <button id="biometric" class="secondary" hidden>Use biometric</button>
+      <p id="error" class="error" role="alert"></p>
+      <a id="reset" href="#" class="reset">Forgot password? Reset…</a>
+    </div>
+    <script src="lock.js"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 3: Create the lock screen logic**
+
+Create `settings-ui/lock.js`:
+
+```js
+const invoke = window.__TAURI__.core.invoke;
+const pwd = document.getElementById("password");
+const errEl = document.getElementById("error");
+
+async function tryUnlock() {
+  const password = pwd.value;
+  if (!password) return;
+  errEl.textContent = "";
+  try {
+    const ok = await invoke("unlock_password", { password });
+    if (!ok) {
+      errEl.textContent = "Wrong password.";
+      pwd.value = "";
+      pwd.focus();
+    }
+  } catch (e) {
+    errEl.textContent = String(e);
+  }
+}
+
+async function tryBiometric() {
+  errEl.textContent = "";
+  try {
+    const ok = await invoke("unlock_biometric");
+    if (!ok) errEl.textContent = "Biometric authentication failed — enter your password.";
+  } catch (e) {
+    errEl.textContent = String(e);
+  }
+}
+
+async function init() {
+  document.getElementById("unlock").addEventListener("click", tryUnlock);
+  pwd.addEventListener("keydown", (e) => { if (e.key === "Enter") tryUnlock(); });
+
+  const bio = document.getElementById("biometric");
+  bio.addEventListener("click", tryBiometric);
+
+  document.getElementById("reset").addEventListener("click", async (e) => {
+    e.preventDefault();
+    const ok = confirm(
+      "Reset whatRust?\n\nThis logs out ALL accounts and removes the app lock. " +
+      "You will need to re-scan the WhatsApp QR code. Your chats stay on your phone."
+    );
+    if (!ok) return;
+    try {
+      await invoke("reset_app_lock");
+    } catch (err) {
+      errEl.textContent = String(err);
+    }
+  });
+
+  try {
+    const s = await invoke("get_lock_status");
+    if (s.biometric_enabled) {
+      bio.textContent = "Use " + s.biometric_label;
+      bio.hidden = false;
+      tryBiometric(); // auto-prompt on load
+    }
+  } catch (_) {
+    // status unavailable — password still works
+  }
+  pwd.focus();
+}
+
+window.addEventListener("DOMContentLoaded", init);
+```
+
+- [ ] **Step 4: Create the lock screen styles**
+
+Create `settings-ui/lock.css`:
+
+```css
+:root { color-scheme: light dark; }
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: #0b141a;
+  color: #e9edef;
+}
+.lock-card {
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 28px;
+  text-align: center;
+}
+.lock-glyph { font-size: 44px; }
+h1 { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+input[type="password"] {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #2a3942;
+  background: #202c33;
+  color: #e9edef;
+  font-size: 15px;
+}
+button {
+  padding: 10px 12px;
+  border: none;
+  border-radius: 8px;
+  background: #00a884;
+  color: #fff;
+  font-size: 15px;
+  cursor: pointer;
+}
+button.secondary { background: #2a3942; }
+.error { color: #f15c6d; min-height: 1.2em; margin: 0; font-size: 13px; }
+.reset { color: #8696a0; font-size: 13px; text-decoration: none; margin-top: 8px; }
+.reset:hover { text-decoration: underline; }
+```
+
+- [ ] **Step 5: Verify it compiles (commands come in Task 4)**
+
+Run: `cd src-tauri && cargo build`
+Expected: builds (the new files are static assets + JSON; no Rust references yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/capabilities/lock.json settings-ui/lock.html settings-ui/lock.js settings-ui/lock.css
+git commit -m "feat(applock): lock-window capability + lock screen UI"
+```
+
+---
+
+### Task 4: Lock commands + command guards + setup wiring
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/window.rs` (defer `show_active` to the lock window when locked)
+
+- [ ] **Step 1: Defer `show_active` to the lock window when locked**
+
+In `src-tauri/src/window.rs`, at the top of `show_active` (before the `ActiveAccount` lookup at line ~233):
+
+```rust
+pub fn show_active(app: &AppHandle) {
+    // If the app is locked, any "reveal" request shows the lock screen, never an
+    // account window. Covers tray click, global shortcut, single-instance, macOS Reopen.
+    if !crate::lock::is_unlocked(app) {
+        crate::lock::show_lock_window(app);
+        return;
+    }
+    if let Some(active) = app.try_state::<ActiveAccount>() {
+        // ... existing body unchanged ...
+```
+
+- [ ] **Step 2: Add the lock commands + guards to `commands.rs`**
+
+In `src-tauri/src/commands.rs`, add `use` for the new modules at the top (next to the existing `use crate::...` lines):
+
+```rust
+use crate::applock::{self, AppLockConfig};
+use crate::lock;
+```
+
+Add `lock::require_unlocked(&app)?;` immediately after the existing `is_remote` check in each of these commands: `get_settings`, `set_settings`, `open_settings`, `list_accounts`, `add_account`, `remove_account`, `rename_account`, `open_account`. Example for `get_settings`:
+
+```rust
+#[tauri::command]
+pub fn get_settings(window: tauri::Window, app: tauri::AppHandle) -> Result<Settings, String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    Ok(crate::settings::load(&app))
+}
+```
+
+(`open_settings` returns `()`, so change its signature to `-> Result<(), String>` and `return Ok(())` paths — update `lib.rs` handler list accordingly; the JS `invoke("open_settings")` ignores the result.)
+
+Append the new commands at the end of `commands.rs` (before the `#[cfg(test)]` module):
+
+```rust
+// ---------------------------------------------------------------------------
+// App-lock commands.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LockStatus {
+    pub enabled: bool,
+    pub biometric_available: bool,
+    pub biometric_enabled: bool,
+    pub biometric_label: String,
+    pub lock_on_launch: bool,
+    pub lock_on_hide: bool,
+    pub idle_secs: u32,
+}
+
+/// Read-only status for BOTH the settings window and the lock screen. Never returns
+/// the password hash. Allowed from any non-remote window, even while locked.
+#[tauri::command]
+pub fn get_lock_status(window: tauri::Window, app: tauri::AppHandle) -> Result<LockStatus, String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    let c = applock::load(&app);
+    let available = matches!(crate::biometric::availability(), crate::biometric::Availability::Available);
+    Ok(LockStatus {
+        enabled: c.is_active(),
+        biometric_available: available,
+        biometric_enabled: c.biometric_enabled && available,
+        biometric_label: crate::biometric::label().to_string(),
+        lock_on_launch: c.lock_on_launch,
+        lock_on_hide: c.lock_on_hide,
+        idle_secs: c.idle_secs,
+    })
+}
+
+/// Enable the lock by setting the first password. Errors if already enabled (use
+/// `change_app_lock_password`). Runs only from an unlocked, local window.
+#[tauri::command]
+pub fn set_app_lock_password(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    new: String,
+    confirm: String,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    if c.is_active() {
+        return Err("app lock is already enabled".into());
+    }
+    if new != confirm {
+        return Err("passwords do not match".into());
+    }
+    if new.chars().count() < 4 {
+        return Err("password must be at least 4 characters".into());
+    }
+    c.password_phc = Some(applock::hash_password(&new)?);
+    c.enabled = true;
+    applock::save(&app, &c).map_err(|e| e.to_string())?;
+    crate::tray::rebuild_menu(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn change_app_lock_password(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    current: String,
+    new: String,
+    confirm: String,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    let phc = c.password_phc.clone().ok_or("app lock is not enabled")?;
+    if !applock::verify_password(&current, &phc) {
+        return Err("current password is incorrect".into());
+    }
+    if new != confirm {
+        return Err("passwords do not match".into());
+    }
+    if new.chars().count() < 4 {
+        return Err("password must be at least 4 characters".into());
+    }
+    c.password_phc = Some(applock::hash_password(&new)?);
+    applock::save(&app, &c).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn disable_app_lock(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    current: String,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    let phc = c.password_phc.clone().ok_or("app lock is not enabled")?;
+    if !applock::verify_password(&current, &phc) {
+        return Err("current password is incorrect".into());
+    }
+    c = AppLockConfig::default(); // fully reset: disabled, no hash, no biometric, default triggers
+    applock::save(&app, &c).map_err(|e| e.to_string())?;
+    crate::tray::rebuild_menu(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn set_app_lock_options(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    lock_on_launch: bool,
+    lock_on_hide: bool,
+    idle_secs: u32,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    c.lock_on_launch = lock_on_launch;
+    c.lock_on_hide = lock_on_hide;
+    c.idle_secs = idle_secs;
+    applock::save(&app, &c).map_err(|e| e.to_string())
+}
+
+/// Enable/disable biometric. Enabling requires the lock to be set, the platform to
+/// report Available, and one successful test authentication.
+#[tauri::command]
+pub fn set_biometric_enabled(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    enabled: bool,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    if enabled {
+        if !c.is_active() {
+            return Err("set an app-lock password first".into());
+        }
+        if !matches!(crate::biometric::availability(), crate::biometric::Availability::Available) {
+            return Err("biometric authentication is not available on this device".into());
+        }
+        if !crate::biometric::authenticate(&app, "Enable biometric unlock for whatRust")? {
+            return Err("biometric test did not succeed".into());
+        }
+    }
+    c.biometric_enabled = enabled;
+    applock::save(&app, &c).map_err(|e| e.to_string())
+}
+
+/// Manual "Lock now" from the settings window.
+#[tauri::command]
+pub fn lock_app(window: tauri::Window, app: tauri::AppHandle) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    if !applock::load(&app).is_active() {
+        return Err("app lock is not enabled".into());
+    }
+    lock::lock_now(&app);
+    Ok(())
+}
+
+/// Unlock with the password. Lock-window only; works while locked (no require_unlocked).
+#[tauri::command]
+pub fn unlock_password(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    password: String,
+) -> Result<bool, String> {
+    if !lock::is_lock_window(&window) {
+        return Err("forbidden".into());
+    }
+    let c = applock::load(&app);
+    let Some(phc) = c.password_phc else {
+        // No lock configured — treat as already unlocked.
+        lock::unlock(&app);
+        return Ok(true);
+    };
+    if applock::verify_password(&password, &phc) {
+        lock::unlock(&app);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Unlock with biometric. Lock-window only; works while locked.
+#[tauri::command]
+pub fn unlock_biometric(window: tauri::Window, app: tauri::AppHandle) -> Result<bool, String> {
+    if !lock::is_lock_window(&window) {
+        return Err("forbidden".into());
+    }
+    if !applock::load(&app).biometric_enabled {
+        return Err("biometric unlock is not enabled".into());
+    }
+    if crate::biometric::authenticate(&app, "Unlock whatRust")? {
+        lock::unlock(&app);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Forgot-password reset: wipe ALL account sessions + the app-lock config, then
+/// relaunch fresh (logged out, lock disabled). Lock-window only.
+#[tauri::command]
+pub fn reset_app_lock(window: tauri::Window, app: tauri::AppHandle) -> Result<(), String> {
+    if !lock::is_lock_window(&window) {
+        return Err("forbidden".into());
+    }
+    crate::applock::reset_all(&app);
+    app.restart();
+}
+```
+
+- [ ] **Step 3: Add `reset_all` to `applock.rs`**
+
+Append to `src-tauri/src/applock.rs` (above `#[cfg(test)]`):
+
+```rust
+/// Factory-reset everything the lock could gate: every account profile dir, the
+/// default webview store, accounts.json, and app-lock.json. Used by the forgot-
+/// password reset. Best-effort: ignores individual delete errors.
+pub fn reset_all(app: &AppHandle) {
+    // Per-account isolated profiles + the default shared store.
+    let f = crate::accounts::load(app);
+    for a in &f.accounts {
+        crate::accounts::delete_profile(app, &a.id);
+    }
+    if let Ok(dir) = app.path().app_config_dir() {
+        let _ = std::fs::remove_file(dir.join("accounts.json"));
+        let _ = std::fs::remove_file(dir.join("app-lock.json"));
+    }
+    // The default account's webview data lives under the app data dir.
+    if let Ok(data) = app.path().app_data_dir() {
+        // Remove only known webview store dirs; do not nuke the whole data dir blindly.
+        for sub in ["EBWebView", "default"] {
+            let _ = std::fs::remove_dir_all(data.join(sub));
+        }
+    }
+}
+```
+
+> Note for the implementer: confirm against `accounts::delete_profile` and `accounts::profile_dir` what the default store path actually is on each OS, and adjust the `["EBWebView", "default"]` list. The unit test below pins the contract for the config-dir files; the webview-store removal is best-effort and verified in the smoke test.
+
+- [ ] **Step 4: Add a reset unit test (config-dir files)**
+
+Add to `applock.rs` tests module:
+
+```rust
+    #[test]
+    fn config_files_have_stable_names() {
+        // The reset + storage contract depends on these exact filenames.
+        assert_eq!(super::config_path_name(), "app-lock.json");
+    }
+```
+
+And add this tiny helper next to `config_path`:
+
+```rust
+#[cfg(test)]
+fn config_path_name() -> &'static str {
+    "app-lock.json"
+}
+```
+
+- [ ] **Step 5: Wire `lib.rs` — manage state, register commands, lock on launch**
+
+In `src-tauri/src/lib.rs`:
+
+(a) Add modules `mod biometric;` and `mod lock;` (lock added in Task 2) at the top.
+
+(b) Register every new command in `invoke_handler` (after `commands::open_account`):
+
+```rust
+            commands::get_lock_status,
+            commands::set_app_lock_password,
+            commands::change_app_lock_password,
+            commands::disable_app_lock,
+            commands::set_app_lock_options,
+            commands::set_biometric_enabled,
+            commands::lock_app,
+            commands::unlock_password,
+            commands::unlock_biometric,
+            commands::reset_app_lock,
+```
+
+(c) In `setup`, after `let mut f = accounts::load(handle);` and the store-uuid backfill, decide the initial lock state and open windows hidden if locking on launch:
+
+```rust
+            // App lock: decide the initial state and whether to start hidden.
+            let lock_cfg = applock::load(handle);
+            let lock_on_launch = lock_cfg.is_active() && lock_cfg.lock_on_launch;
+            handle.manage(lock::LockState::new(!lock_on_launch));
+            let open_hidden = start_hidden || lock_on_launch;
+```
+
+Change the account-window loop to use `open_hidden` instead of `start_hidden`:
+
+```rust
+            for a in &f.accounts {
+                window::open_account_window(handle, a, open_hidden)?;
+            }
+```
+
+After `tray::setup` + `tray::rebuild_menu` + `settings::apply`, show the lock screen when locking on launch and not minimized to tray:
+
+```rust
+            if lock_on_launch && !start_hidden {
+                lock::show_lock_window(handle);
+            }
+```
+
+- [ ] **Step 6: Stub `biometric` so it compiles now (real impl in Task 8)**
+
+Create `src-tauri/src/biometric/mod.rs` with a temporary always-unsupported body (replaced in Task 8):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Availability {
+    Available,
+    NotConfigured,
+    Unsupported,
+}
+
+pub fn availability() -> Availability {
+    Availability::Unsupported
+}
+
+pub fn authenticate(_app: &tauri::AppHandle, _reason: &str) -> Result<bool, String> {
+    Err("biometric authentication is not available on this platform".into())
+}
+
+pub fn label() -> &'static str {
+    "biometric"
+}
+```
+
+- [ ] **Step 7: Build + run all tests**
+
+Run: `cd src-tauri && cargo build && cargo test --lib`
+Expected: builds; all existing + new tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/src/ 
+git commit -m "feat(applock): lock/unlock commands, command guards, lock-on-launch wiring"
+```
+
+---
+
+### Task 5: Triggers — tray "Lock now", lock-on-hide, idle watcher
+
+**Files:**
+- Modify: `src-tauri/src/tray.rs`
+- Modify: `src-tauri/src/window.rs` (close-to-tray handler)
+- Modify: `src-tauri/src/lib.rs` (idle watcher thread)
+- Modify: `src-tauri/Cargo.toml` (add `user-idle`)
+
+- [ ] **Step 1: Add "Lock now" to the tray menu when the lock is active**
+
+In `src-tauri/src/tray.rs`, in `rebuild_menu`, after building the `quit` item and before constructing the final menu, conditionally insert a lock item. First, load the lock config near the top of `rebuild_menu`:
+
+```rust
+    let lock_active = crate::applock::load(app).is_active();
+```
+
+Then build a `lock` item and include it before `quit`:
+
+```rust
+    let mut tail = builder.separator().item(&accounts_item).item(&settings).item(&reload);
+    if lock_active {
+        let Ok(lock_item) = MenuItemBuilder::with_id("lock", "Lock now").build(app) else {
+            return;
+        };
+        tail = tail.item(&lock_item);
+    }
+    let menu = match tail.item(&quit).build() {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+    let _ = tray.set_menu(Some(menu));
+```
+
+(Replace the existing `.separator().item(...)...build()` chain with the above.)
+
+Add the menu handler in `on_menu_event` (in `setup`), in the `match id` block before `"quit"`:
+
+```rust
+                "lock" => crate::lock::lock_now(app),
+```
+
+- [ ] **Step 1b: Guard tray actions while locked (closes a bypass)**
+
+The tray's account items and "Settings"/"Accounts"/"Reload" call `show_account` /
+`open_settings_window` **directly**, bypassing the command guards — so while locked they
+would reveal content over the lock screen. Add a guard at the very top of
+`on_menu_event` (before the `acct:` prefix check), so any reveal action defers to the
+lock window while locked. `quit` is always allowed.
+
+```rust
+        .on_menu_event(|app, event| {
+            let id = event.id().as_ref();
+            // While locked, every menu action except Quit just (re)shows the lock screen.
+            if !crate::lock::is_unlocked(app) && id != "quit" {
+                crate::lock::show_lock_window(app);
+                return;
+            }
+            if let Some(acct_id) = id.strip_prefix("acct:") {
+                // ... existing body unchanged ...
+```
+
+Note: `unlock()` sets `unlocked = true` **before** it calls `show_account` to restore
+windows, so this guard never blocks the restore path. Do **not** add the guard to
+`show_account` itself.
+
+- [ ] **Step 2: Lock-on-hide in the close-to-tray handler**
+
+In `src-tauri/src/window.rs`, replace the body of the `CloseRequested` handler in `open_account_window` (lines ~46-54):
+
+```rust
+    win.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            if crate::settings::load(&app_handle).close_to_tray {
+                let lc = crate::applock::load(&app_handle);
+                if lc.is_active() && lc.lock_on_hide {
+                    crate::lock::lock_now(&app_handle);
+                } else if let Some(w) = app_handle.get_webview_window(&label_for_close) {
+                    let _ = w.hide();
+                }
+                api.prevent_close();
+            }
+        }
+    });
+```
+
+- [ ] **Step 3: Add the idle dependency**
+
+In `src-tauri/Cargo.toml`, under the shared desktop dependencies block (the `[target.'cfg(any(...))'.dependencies]` table):
+
+```toml
+user-idle = "0.6"  # system idle time for the idle auto-lock trigger
+```
+
+- [ ] **Step 4: Spawn the idle watcher in `setup`**
+
+In `src-tauri/src/lib.rs` `setup`, after the lock-on-launch block, spawn a watcher that re-reads config each tick (so runtime changes take effect) and locks when idle crosses the threshold. Window mutation must happen on the main thread:
+
+```rust
+            // Idle auto-lock watcher. Always running; no-op unless the lock is active
+            // with idle_secs > 0 and the app is currently unlocked.
+            #[cfg(desktop)]
+            {
+                let idle_handle = handle.clone();
+                std::thread::spawn(move || loop {
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    let c = applock::load(&idle_handle);
+                    if !c.is_active() || c.idle_secs == 0 {
+                        continue;
+                    }
+                    if !lock::is_unlocked(&idle_handle) {
+                        continue;
+                    }
+                    let idle_ok = user_idle::UserIdle::get_time()
+                        .map(|t| t.as_seconds() >= c.idle_secs as u64)
+                        .unwrap_or(false);
+                    if idle_ok {
+                        let h = idle_handle.clone();
+                        let _ = idle_handle.run_on_main_thread(move || lock::lock_now(&h));
+                    }
+                });
+            }
+```
+
+> De-risk status (verified): `user_idle::UserIdle::get_time() -> Result<UserIdle, _>` and `UserIdle::as_seconds() -> u64` are correct for `user-idle` 0.6.0. **Known limitation:** 0.6.0's default backend is X11/XScreenSaver (`default = ["x11"]`); on a **native Wayland** session it returns 0 / unreliable (works only under XWayland), and there is no Wayland idle backend in 0.6.0 (only a non-default `dbus` feature). Idle auto-lock is off by default, which mitigates this — document it as a known caveat in the README/settings.
+
+- [ ] **Step 5: Build + test**
+
+Run: `cd src-tauri && cargo build && cargo test --lib`
+Expected: builds; tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/ src-tauri/Cargo.toml src-tauri/Cargo.lock
+git commit -m "feat(applock): tray Lock now, lock-on-hide, idle auto-lock watcher"
+```
+
+---
+
+### Task 6: Suppress notification bodies while locked
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs` (`notify`)
+
+- [ ] **Step 1: Add the locked check to `notify`**
+
+In `src-tauri/src/commands.rs`, at the very top of `notify` (before the `notifications` setting check):
+
+```rust
+#[tauri::command]
+pub fn notify(window: tauri::Window, app: tauri::AppHandle, title: String, body: String) {
+    // While locked, suppress notifications entirely so message previews don't leak
+    // to the OS notification center / lock screen. The tray unread badge still updates
+    // via set_unread (a count only, no content).
+    if !crate::lock::is_unlocked(&app) {
+        return;
+    }
+    if !crate::settings::load(&app).notifications {
+        return;
+    }
+    // ... rest unchanged ...
+```
+
+- [ ] **Step 2: Build + test**
+
+Run: `cd src-tauri && cargo build && cargo test --lib`
+Expected: builds; tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/src/commands.rs
+git commit -m "feat(applock): suppress notifications while locked"
+```
+
+---
+
+### Task 7: Settings "Security" section + status wiring
+
+**Files:**
+- Modify: `settings-ui/index.html`
+- Modify: `settings-ui/main.js`
+- Modify: `settings-ui/style.css`
+
+- [ ] **Step 1: Add the Security section markup**
+
+In `settings-ui/index.html`, after the hotkey `<label class="field">…</label>` block and before the `<div class="actions">`:
+
+```html
+    <hr class="divider" />
+    <h2 class="section-title">Security</h2>
+
+    <div id="lock-disabled">
+      <label class="field"><span>App-lock password (min 4 characters)</span>
+        <input type="password" id="lock_pw1" autocomplete="new-password" /></label>
+      <label class="field"><span>Confirm password</span>
+        <input type="password" id="lock_pw2" autocomplete="new-password" /></label>
+      <button id="enable_lock">Enable app lock</button>
+    </div>
+
+    <div id="lock-enabled" hidden>
+      <label class="row" id="biometric_row" hidden>
+        <input type="checkbox" id="biometric_enabled" /> <span id="biometric_label">Use biometric</span>
+      </label>
+      <label class="row"><input type="checkbox" id="lock_on_launch" /> <span>Lock on launch</span></label>
+      <label class="row"><input type="checkbox" id="lock_on_hide" /> <span>Lock when hidden to tray</span></label>
+      <label class="field"><span>Auto-lock when idle (minutes, 0 = off)</span>
+        <input type="number" id="idle_min" min="0" step="1" value="0" /></label>
+      <div class="actions">
+        <button id="lock_now">Lock now</button>
+        <button id="change_pw" class="secondary">Change password…</button>
+        <button id="disable_lock" class="secondary">Disable…</button>
+      </div>
+    </div>
+
+    <p class="lock-note">App lock controls who can open whatRust's windows. It does
+      <strong>not</strong> encrypt your data on disk.</p>
+```
+
+- [ ] **Step 2: Add the Security logic to `main.js`**
+
+Append to `settings-ui/main.js` (and call `loadLock()` from the `DOMContentLoaded` handler):
+
+```js
+// --- App lock ---
+
+async function loadLock() {
+  let s;
+  try {
+    s = await invoke("get_lock_status");
+  } catch (e) {
+    return;
+  }
+  const disabled = document.getElementById("lock-disabled");
+  const enabled = document.getElementById("lock-enabled");
+  disabled.hidden = s.enabled;
+  enabled.hidden = !s.enabled;
+
+  if (s.enabled) {
+    const row = document.getElementById("biometric_row");
+    row.hidden = !s.biometric_available;
+    document.getElementById("biometric_label").textContent = "Use " + s.biometric_label;
+    document.getElementById("biometric_enabled").checked = s.biometric_enabled;
+    document.getElementById("lock_on_launch").checked = s.lock_on_launch;
+    document.getElementById("lock_on_hide").checked = s.lock_on_hide;
+    document.getElementById("idle_min").value = String(Math.round(s.idle_secs / 60));
+  }
+}
+
+async function saveLockOptions() {
+  const idleMin = parseInt(document.getElementById("idle_min").value, 10) || 0;
+  await invoke("set_app_lock_options", {
+    lockOnLaunch: document.getElementById("lock_on_launch").checked,
+    lockOnHide: document.getElementById("lock_on_hide").checked,
+    idleSecs: Math.max(0, idleMin) * 60,
+  });
+}
+
+function wireLock() {
+  document.getElementById("enable_lock").addEventListener("click", async () => {
+    const a = document.getElementById("lock_pw1").value;
+    const b = document.getElementById("lock_pw2").value;
+    try {
+      await invoke("set_app_lock_password", { new: a, confirm: b });
+      document.getElementById("lock_pw1").value = "";
+      document.getElementById("lock_pw2").value = "";
+      await loadLock();
+    } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("lock_now").addEventListener("click", async () => {
+    try { await invoke("lock_app"); } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("change_pw").addEventListener("click", async () => {
+    const current = prompt("Current password:");
+    if (current === null) return;
+    const next = prompt("New password (min 4):");
+    if (!next) return;
+    try {
+      await invoke("change_app_lock_password", { current, new: next, confirm: next });
+      alert("Password changed.");
+    } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("disable_lock").addEventListener("click", async () => {
+    const current = prompt("Enter your current password to disable the lock:");
+    if (current === null) return;
+    try {
+      await invoke("disable_app_lock", { current });
+      await loadLock();
+    } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("biometric_enabled").addEventListener("change", async (e) => {
+    try {
+      await invoke("set_biometric_enabled", { enabled: e.target.checked });
+    } catch (err) {
+      alert(String(err));
+      e.target.checked = !e.target.checked; // revert on failure
+    }
+    await loadLock();
+  });
+
+  for (const id of ["lock_on_launch", "lock_on_hide"]) {
+    document.getElementById(id).addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
+  }
+  document.getElementById("idle_min").addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
+}
+```
+
+In the existing `DOMContentLoaded` handler, add:
+
+```js
+  loadLock();
+  wireLock();
+```
+
+- [ ] **Step 3: Add styles**
+
+Append to `settings-ui/style.css`:
+
+```css
+.lock-note { font-size: 12px; color: #8696a0; margin-top: 10px; line-height: 1.4; }
+#lock-enabled .field input[type="number"] { width: 80px; }
+```
+
+- [ ] **Step 4: Build + smoke check**
+
+Run: `cd src-tauri && cargo build`
+Expected: builds. (UI is exercised in the Task 10 smoke test.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add settings-ui/
+git commit -m "feat(applock): Settings Security section (enable/disable/triggers/biometric)"
+```
+
+---
+
+### Task 8: Biometric — per-platform native modules
+
+**Files:**
+- Replace: `src-tauri/src/biometric/mod.rs` (dispatch + `compile_error!` catch-all)
+- Create: `src-tauri/src/biometric/linux.rs`
+- Create: `src-tauri/src/biometric/windows.rs`
+- Create: `src-tauri/src/biometric/macos.rs`
+- Modify: `src-tauri/Cargo.toml` (per-target deps)
+- Create: `src-tauri/resources/com.karem.whatrust.policy` (Linux polkit action)
+- Modify: `src-tauri/tauri.conf.json` (bundle the policy on Linux)
+
+> Order of implementation: Linux first (the dev target — smoke-testable here), then Windows, then macOS (both hardware-pending). Each `authenticate` is **blocking** and returns `Ok(true)` only on a confirmed verification. **All three are subject to the de-risk verification pass — the exact API shapes below are best-effort and must be confirmed against the resolved crate versions.**
+
+- [ ] **Step 1: Replace the dispatch module**
+
+Replace `src-tauri/src/biometric/mod.rs`:
+
+```rust
+//! Per-platform desktop biometric / local-auth. The default ("password-only") account
+//! never touches this; it's an optional unlock shortcut. Every backend returns a plain
+//! yes/no — no key material — so it can gate the UI but cannot decrypt anything.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Availability {
+    /// Usable now (Hello configured / Touch ID enrolled / polkit reachable).
+    Available,
+    /// The mechanism exists but isn't set up (no enrolled print, no agent, etc.).
+    NotConfigured,
+    /// Not supported on this OS / version.
+    Unsupported,
+}
+
+#[cfg(target_os = "linux")]
+#[path = "linux.rs"]
+mod platform;
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod platform;
+#[cfg(target_os = "macos")]
+#[path = "macos.rs"]
+mod platform;
+
+#[cfg(not(any(target_os = "linux", windows, target_os = "macos")))]
+compile_error!("biometric auth is not implemented for this platform");
+
+pub fn availability() -> Availability {
+    platform::availability()
+}
+
+/// Blocking. `reason` must be non-empty (macOS aborts on an empty reason).
+pub fn authenticate(app: &tauri::AppHandle, reason: &str) -> Result<bool, String> {
+    platform::authenticate(app, reason)
+}
+
+pub fn label() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "Windows Hello"
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "Touch ID"
+    }
+    #[cfg(target_os = "linux")]
+    {
+        "system authentication"
+    }
+}
+```
+
+- [ ] **Step 2: Linux — polkit via zbus**
+
+Add to `src-tauri/Cargo.toml`:
+
+```toml
+[target.'cfg(target_os = "linux")'.dependencies]
+# (existing webkit2gtk line stays)
+zbus = "5"
+zbus_polkit = "5.0.0"
+```
+
+Create `src-tauri/src/biometric/linux.rs`:
+
+> **De-risk-corrected (Blockers C + D):** use the **blocking** proxy
+> `AuthorityProxyBlocking` (the async `AuthorityProxy` needs `&zbus::Connection` +
+> `.await` and will NOT type-check against a `zbus::blocking::Connection`), and a
+> unifying `Box<dyn Error>` return inside the helper because `Subject::new_for_owner`
+> yields `zbus_polkit::Error` while the proxy calls yield `zbus::Error` — a single
+> `zbus::Result` cannot absorb both via `?`.
+
+```rust
+use super::Availability;
+use std::collections::HashMap;
+use zbus::blocking::Connection;
+use zbus_polkit::policykit1::{AuthorityProxyBlocking, CheckAuthorizationFlags, Subject};
+
+const ACTION_ID: &str = "com.karem.whatrust.unlock";
+
+pub fn availability() -> Availability {
+    // Connection::system() and AuthorityProxyBlocking::new both return zbus::Result,
+    // so and_then unifies cleanly here (no Box needed).
+    match Connection::system().and_then(|c| AuthorityProxyBlocking::new(&c)) {
+        Ok(_) => Availability::Available,
+        Err(_) => Availability::NotConfigured,
+    }
+}
+
+pub fn authenticate(_app: &tauri::AppHandle, _reason: &str) -> Result<bool, String> {
+    check_polkit_unlock().map_err(|e| e.to_string())
+}
+
+/// Box<dyn Error> so both zbus::Error and zbus_polkit::Error convert via `?`.
+fn check_polkit_unlock() -> Result<bool, Box<dyn std::error::Error>> {
+    let conn = Connection::system()?;
+    // BLOCKING proxy — async AuthorityProxy would require &zbus::Connection + .await.
+    let authority = AuthorityProxyBlocking::new(&conn)?;
+    // Subject = this process. polkit resolves the action, popping the desktop's polkit
+    // agent dialog (fingerprint where pam_fprintd is configured).
+    // new_for_owner(pid: u32, start_time: Option<u64>, uid: Option<u32>)
+    let subject = Subject::new_for_owner(std::process::id(), None, None)?;
+    let details: HashMap<&str, &str> = HashMap::new();
+    let result = authority.check_authorization(
+        &subject,
+        ACTION_ID,
+        &details,
+        CheckAuthorizationFlags::AllowUserInteraction.into(), // -> BitFlags<CheckAuthorizationFlags>
+        "", // cancellation_id
+    )?;
+    Ok(result.is_authorized)
+}
+```
+
+Create `src-tauri/resources/com.karem.whatrust.policy`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>whatRust</vendor>
+  <action id="com.karem.whatrust.unlock">
+    <description>Unlock whatRust</description>
+    <message>Authenticate to unlock whatRust</message>
+    <defaults>
+      <allow_any>auth_self</allow_any>
+      <allow_inactive>auth_self</allow_inactive>
+      <allow_active>auth_self</allow_active>
+    </defaults>
+  </action>
+</policyconfig>
+```
+
+In `src-tauri/tauri.conf.json`, add a Linux resource so the `.deb` installs the policy. Under `bundle`, add:
+
+```json
+    "linux": {
+      "deb": {
+        "files": {
+          "/usr/share/polkit-1/actions/com.karem.whatrust.policy": "resources/com.karem.whatrust.policy"
+        }
+      }
+    }
+```
+
+> Note: AppImage and Flatpak/Snap cannot install the polkit action → `availability()` returns `NotConfigured`/`Available`-but-`auth_admin` and the password is used instead. This is the documented best-effort posture.
+
+- [ ] **Step 3: Windows — Windows Hello**
+
+Add to `src-tauri/Cargo.toml`:
+
+**Edit the existing `windows = {...}` line** (do not add a second one) to MERGE the
+Hello features with what's already there. The existing line has `Win32_Foundation` +
+`Win32_System_Com` (keep them for the webview2 media handler); add the three Hello
+features. Tauri 2.11.2 / wry 0.55.1 / tao 0.35.3 / webview2-com 0.38.2 all sit on
+`windows` 0.61.x — keep the pin at 0.61 (do NOT bump to 0.62) so `window.hwnd()`'s HWND
+unifies. Verify on Windows with `cargo tree -p windows`.
+
+```toml
+[target.'cfg(windows)'.dependencies]
+webview2-com = "0.38"
+windows = { version = "0.61", features = [
+  "Win32_Foundation",         # existing
+  "Win32_System_Com",         # existing (webview2 permission handler)
+  "Security_Credentials_UI",  # UserConsentVerifier + result/availability enums
+  "Win32_System_WinRT",       # IUserConsentVerifierInterop
+  "Foundation",               # IAsyncOperation
+] }
+windows-core = "0.61"
+```
+
+Create `src-tauri/src/biometric/windows.rs`:
+
+> **De-risk-corrected (Blocker A):** `IUserConsentVerifierInterop` is NOT in
+> `Security::Credentials::UI` — it is generated under `Win32::System::WinRT`. Importing
+> it from the wrong module is a hard compile error. Also: `op.get()` blocks until the
+> user responds — fine here because biometric commands run on Tauri's async runtime
+> thread, not the UI/main thread. `factory()` auto-inits COM (MTA); no manual
+> `CoInitializeEx` needed.
+
+```rust
+use super::Availability;
+use tauri::Manager;
+use windows::core::{factory, HSTRING};
+use windows::Foundation::IAsyncOperation;
+use windows::Security::Credentials::UI::{
+    UserConsentVerificationResult, UserConsentVerifier, UserConsentVerifierAvailability,
+};
+// IUserConsentVerifierInterop lives in Win32::System::WinRT, NOT Security::Credentials::UI:
+use windows::Win32::System::WinRT::IUserConsentVerifierInterop;
+
+pub fn availability() -> Availability {
+    match UserConsentVerifier::CheckAvailabilityAsync().and_then(|op| op.get()) {
+        Ok(UserConsentVerifierAvailability::Available) => Availability::Available,
+        Ok(_) => Availability::NotConfigured,
+        Err(_) => Availability::Unsupported,
+    }
+}
+
+pub fn authenticate(app: &tauri::AppHandle, reason: &str) -> Result<bool, String> {
+    // MUST query availability first, or RequestVerification hangs.
+    let _ = UserConsentVerifier::CheckAvailabilityAsync().and_then(|op| op.get());
+
+    let win = app
+        .get_webview_window("lock")
+        .or_else(|| app.webview_windows().into_values().next())
+        .ok_or("no window to host the Hello prompt")?;
+    let hwnd = win.hwnd().map_err(|e| e.to_string())?;
+
+    let interop: IUserConsentVerifierInterop =
+        factory::<UserConsentVerifier, IUserConsentVerifierInterop>().map_err(|e| e.to_string())?;
+    let msg = HSTRING::from(reason);
+    let op: IAsyncOperation<UserConsentVerificationResult> =
+        unsafe { interop.RequestVerificationForWindowAsync(hwnd, &msg) }.map_err(|e| e.to_string())?;
+    match op.get() {
+        Ok(UserConsentVerificationResult::Verified) => Ok(true),
+        Ok(_) => Ok(false),
+        Err(e) => Err(e.to_string()),
+    }
+}
+```
+
+> De-risk status (verified): `factory::<UserConsentVerifier, IUserConsentVerifierInterop>()` auto-inits COM (MTA) — no manual `CoInitializeEx` needed; `RequestVerificationForWindowAsync` takes `HWND` **by value** + `&HSTRING` (confirmed for `windows` 0.61); `op.get()` blocks (fine off the UI thread). Still verify on real Windows hardware: whether the prompt needs a foreground nudge (may open behind the window).
+
+- [ ] **Step 4: macOS — Touch ID**
+
+Add to `src-tauri/Cargo.toml`. **De-risk-corrected:** `objc2-local-authentication` must
+enable `["LAContext", "block2"]` (the `LAContext`/`LAPolicy` types and the
+`evaluatePolicy_localizedReason_reply` method are feature-gated — without these it
+"compiles" but the symbols are missing). Extend the **existing** `objc2-foundation` line
+(which already has `NSProcessInfo` for the macOS-14 isolation check) to also expose
+`NSString` + `NSError`. Verified compatible ranges: `objc2` 0.6.x, `block2` 0.6.x,
+`objc2-foundation` 0.3.2.
+
+```toml
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-foundation = { version = "0.3", features = ["NSProcessInfo", "NSString", "NSError"] }
+objc2-local-authentication = { version = "0.3.2", features = ["LAContext", "block2"] }
+objc2 = "0.6"
+block2 = "0.6"
+```
+
+Create `src-tauri/src/biometric/macos.rs`:
+
+```rust
+use super::Availability;
+use block2::RcBlock;
+use objc2_foundation::NSString;
+use objc2_local_authentication::{LAContext, LAPolicy};
+use std::sync::mpsc;
+
+pub fn availability() -> Availability {
+    let ctx = unsafe { LAContext::new() };
+    let can = unsafe {
+        ctx.canEvaluatePolicy_error(LAPolicy::DeviceOwnerAuthenticationWithBiometrics)
+    };
+    match can {
+        Ok(()) => Availability::Available,
+        Err(_) => Availability::NotConfigured,
+    }
+}
+
+pub fn authenticate(_app: &tauri::AppHandle, reason: &str) -> Result<bool, String> {
+    // Fresh context per call (LAContext caches a prior success).
+    let ctx = unsafe { LAContext::new() };
+    let reason = if reason.is_empty() { "Unlock whatRust" } else { reason };
+    let ns_reason = NSString::from_str(reason);
+
+    let (tx, rx) = mpsc::channel::<bool>();
+    let block = RcBlock::new(move |success: objc2::runtime::Bool, _err: *mut objc2_foundation::NSError| {
+        let _ = tx.send(success.as_bool());
+    });
+
+    unsafe {
+        // DeviceOwnerAuthentication = Touch ID OR the login password as fallback.
+        ctx.evaluatePolicy_localizedReason_reply(
+            LAPolicy::DeviceOwnerAuthentication,
+            &ns_reason,
+            &block,
+        );
+    }
+
+    // The reply block fires on a background thread; block until it does (with a cap).
+    rx.recv_timeout(std::time::Duration::from_secs(60))
+        .map_err(|_| "biometric prompt timed out".to_string())
+}
+```
+
+> De-risk status (verified): method names/signatures are correct — `canEvaluatePolicy_error(LAPolicy) -> Result<(), Retained<NSError>>` (use `.is_ok()` / match `Ok(())`), `evaluatePolicy_localizedReason_reply(policy, &NSString, &block)`, reply block is `Fn(objc2::runtime::Bool, *mut NSError)` so `success.as_bool()` is correct, and `RcBlock` (not `StackBlock`) is required because the reply fires after the function returns. Still verify on a real Touch-ID Mac: that ad-hoc signing (`codesign -s -`) lets `canEvaluatePolicy` succeed (the one UNCERTAIN claim), and the login-password fallback path.
+
+- [ ] **Step 5: Build per-platform (Linux now; Win/macOS during cross-build)**
+
+Run (Linux dev target): `cd src-tauri && cargo build`
+Expected: builds with the polkit backend. Fix any `zbus_polkit` API mismatches surfaced (see de-risk note).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/biometric/ src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/resources/com.karem.whatrust.policy src-tauri/tauri.conf.json
+git commit -m "feat(applock): per-platform biometric (Linux polkit / Windows Hello / macOS Touch ID)"
+```
+
+---
+
+### Task 9: README + honest framing
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add an App-lock section**
+
+In `README.md`, add a feature bullet and a section (place near the multi-account section). Use this copy:
+
+```markdown
+### Lock the app (optional)
+
+whatRust can require a password — or a fingerprint / Windows Hello / Touch ID where your
+OS supports it — before showing your chats. Enable it under **Settings → Security**.
+
+- **Password** works on every platform (Argon2id, stored locally).
+- **Biometric** is an optional shortcut: Windows Hello (Windows 11), Touch ID (macOS 14+
+  recommended), and the system fingerprint dialog on Linux where polkit/`pam_fprintd` is
+  configured (native `.deb` install; AppImage falls back to the password).
+- Lock **on launch**, **on demand** (tray → *Lock now*), **when hidden to the tray**, or
+  **after an idle timeout** — each toggleable in Settings.
+- Forgot your password? **Reset** from the lock screen logs out all accounts and clears
+  the lock (you'll re-scan the QR). There is no backdoor.
+
+> **What the lock does and doesn't do:** it controls who can open whatRust's windows. It
+> does **not** encrypt your data on disk — your WhatsApp session stays readable to other
+> software running as your user, locked or not (the same posture as Signal Desktop). For
+> at-rest protection, use full-disk encryption (FileVault / BitLocker / LUKS).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document the optional app lock + honest at-rest caveat"
+```
+
+---
+
+### Task 10: Smoke test on Linux
+
+**Files:** none (manual verification).
+
+- [ ] **Step 1: Run the dev build**
+
+Run: `cd src-tauri && cargo tauri dev` (or from repo root `cargo tauri dev`).
+Use an isolated config dir so your real whatRust data is untouched, e.g. prefix with a temporary `XDG_CONFIG_HOME`/`XDG_DATA_HOME` if testing destructive paths.
+
+- [ ] **Step 2: Enable + lock**
+- Settings → Security → set a password → Enable app lock. The tray gains "Lock now".
+- Click **Lock now** → all account/settings windows hide; the lock screen appears, always-on-top, no decorations.
+
+- [ ] **Step 3: Unlock paths**
+- Wrong password → "Wrong password."; correct password → windows restore.
+- Toggle **Lock when hidden to tray** on; close a window → it locks. Toggle off again.
+- Set idle to 1 minute; leave idle → it locks (X11). Note Wayland may not.
+- Restart the app with lock-on-launch → it starts on the lock screen.
+
+- [ ] **Step 4: Biometric (Linux polkit)**
+- On a `.deb`-installed build with a polkit agent + enrolled fingerprint: enable **Use system authentication**; lock; the polkit dialog appears and a fingerprint/password unlocks.
+- Where polkit is unavailable: the toggle is hidden and the password is used.
+
+- [ ] **Step 5: Boundary check**
+- While locked, confirm a hidden `wa-*` window cannot drive account/settings commands (the `require_unlocked` guard). Notifications are suppressed; the tray unread count still updates.
+
+- [ ] **Step 6: Reset**
+- On a throwaway profile: lock → **Forgot password? Reset** → confirm → the app relaunches logged out with the lock disabled.
+
+- [ ] **Step 7: Final commit (if any fixups)**
+
+```bash
+git add -A && git commit -m "test(applock): Linux smoke-test fixups"
+```
+
+---
+
+## Hardware-pending (tracked, not blocking the Linux release)
+- **Windows Hello**: prompt + cancel/fallback on Win11 22000+; confirm `windows` version matches Tauri (`cargo tree -p windows`) and COM init.
+- **macOS Touch ID**: prompt + login-password fallback on a Touch-ID Mac; confirm `objc2-local-authentication` API shapes and that ad-hoc signing suffices.

--- a/docs/superpowers/plans/2026-06-01-shortcut-recorder.md
+++ b/docs/superpowers/plans/2026-06-01-shortcut-recorder.md
@@ -1,0 +1,438 @@
+# Shortcut Recorder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user set the global show/hide shortcut by pressing the key combo ("Record"), and surface shortcut-registration failures instead of swallowing them.
+
+**Architecture:** A "Record" button in the settings webview captures a `keydown` (capture-phase, `preventDefault`) and converts the modifier flags + `event.code` into a Tauri accelerator string via a pure `comboToAccelerator` function (in `settings-ui/hotkey.js`, shared with a node test). The recorded value fills the existing `#hotkey` field; Save persists it. The Rust `settings::apply` is changed to return the global-shortcut registration error, which `set_settings` returns so the UI can warn.
+
+**Tech Stack:** Vanilla JS (no build step), `node` for one pure-function test, Rust + Tauri v2, `tauri-plugin-global-shortcut`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-shortcut-recorder-design.md`
+**Branch:** continue on `feat/app-lock` (stacking on the app-lock work). Run `cargo` from `src-tauri/`.
+
+---
+
+### Task 1: `hotkey.js` — pure accelerator formatter + node test
+
+**Files:**
+- Create: `settings-ui/hotkey.js`
+- Create: `settings-ui/comboToAccelerator.test.mjs`
+
+- [ ] **Step 1: Write the failing node test**
+
+Create `settings-ui/comboToAccelerator.test.mjs`:
+
+```js
+// Zero-dependency assertion script for the pure hotkey formatter.
+// Run: node settings-ui/comboToAccelerator.test.mjs   (exit non-zero on failure)
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// hotkey.js assigns globalThis.HotkeyFmt; run it in this global scope.
+(0, eval)(readFileSync(join(here, "hotkey.js"), "utf8"));
+const { comboToAccelerator, isValidCombo } = globalThis.HotkeyFmt;
+
+let failures = 0;
+function eq(actual, expected, label) {
+  const a = JSON.stringify(actual), e = JSON.stringify(expected);
+  if (a !== e) { console.error(`FAIL ${label}: got ${a}, want ${e}`); failures++; }
+  else { console.log(`ok   ${label}`); }
+}
+const M = (o = {}) => ({ ctrl: false, alt: false, shift: false, meta: false, ...o });
+
+eq(comboToAccelerator(M({ ctrl: true, shift: true }), "KeyW"), "CmdOrCtrl+Shift+W", "Ctrl+Shift+W");
+eq(comboToAccelerator(M(), "F8"), "F8", "bare F8");
+eq(comboToAccelerator(M({ shift: true }), "Digit1"), "Shift+1", "Shift+Digit1 stays 1 (code-based)");
+eq(comboToAccelerator(M({ meta: true }), "KeyK"), "Super+K", "Meta+K -> Super+K");
+eq(comboToAccelerator(M({ ctrl: true, alt: true, shift: true }), "KeyP"), "CmdOrCtrl+Alt+Shift+P", "modifier order");
+eq(comboToAccelerator(M({ ctrl: true }), "ArrowUp"), "CmdOrCtrl+Up", "Ctrl+ArrowUp -> CmdOrCtrl+Up");
+eq(comboToAccelerator(M(), "Comma"), null, "unmapped key -> null");
+
+eq(isValidCombo(M(), "KeyW"), false, "bare letter invalid");
+eq(isValidCombo(M({ shift: true }), "KeyW"), true, "Shift+letter valid (Shift counts)");
+eq(isValidCombo(M(), "F8"), true, "bare F-key valid");
+eq(isValidCombo(M({ ctrl: true }), "KeyW"), true, "Ctrl+letter valid");
+
+if (failures) { console.error(`\n${failures} failing assertion(s)`); process.exit(1); }
+console.log("\nall hotkey tests passed");
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node settings-ui/comboToAccelerator.test.mjs`
+Expected: FAIL — `hotkey.js` doesn't exist yet (`ENOENT` reading the file, or `Cannot read properties of undefined` for `globalThis.HotkeyFmt`). Non-zero exit.
+
+- [ ] **Step 3: Implement `hotkey.js`**
+
+Create `settings-ui/hotkey.js`:
+
+```js
+// Pure helpers: turn a captured key combo into a Tauri accelerator string.
+// Assigned to globalThis.HotkeyFmt so the page (window.HotkeyFmt, since
+// window === globalThis in a browser) and the node test share ONE source.
+// MUST NOT reference `window` (undefined under node).
+(function () {
+  const FN_KEY = /^F([1-9]|1[0-9]|2[0-4])$/;
+
+  function keyToken(code) {
+    if (/^Key[A-Z]$/.test(code)) return code.slice(3);   // KeyW -> W
+    if (/^Digit[0-9]$/.test(code)) return code.slice(5); // Digit1 -> 1
+    if (FN_KEY.test(code)) return code;                  // F8 -> F8
+    switch (code) {
+      case "ArrowUp": return "Up";
+      case "ArrowDown": return "Down";
+      case "ArrowLeft": return "Left";
+      case "ArrowRight": return "Right";
+      case "Space": return "Space";
+      default: return null;                              // unmapped
+    }
+  }
+
+  // mods: {ctrl, alt, shift, meta}; code: KeyboardEvent.code.
+  // Returns the accelerator string, or null if the key is unmapped.
+  function comboToAccelerator(mods, code) {
+    const key = keyToken(code);
+    if (key === null) return null;
+    const parts = [];
+    if (mods.ctrl) parts.push("CmdOrCtrl");
+    if (mods.alt) parts.push("Alt");
+    if (mods.shift) parts.push("Shift");
+    if (mods.meta) parts.push("Super");
+    parts.push(key);
+    return parts.join("+");
+  }
+
+  // Accept only if there is a modifier, or the key itself is a function key.
+  function isValidCombo(mods, code) {
+    if (mods.ctrl || mods.alt || mods.shift || mods.meta) return true;
+    return FN_KEY.test(code);
+  }
+
+  globalThis.HotkeyFmt = { comboToAccelerator, isValidCombo, FN_KEY };
+})();
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node settings-ui/comboToAccelerator.test.mjs`
+Expected: PASS — all `ok` lines, `all hotkey tests passed`, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add settings-ui/hotkey.js settings-ui/comboToAccelerator.test.mjs
+git commit -m "feat(hotkey): pure combo->accelerator formatter + node test"
+```
+
+---
+
+### Task 2: Settings markup + styles for the recorder
+
+**Files:**
+- Modify: `settings-ui/index.html`
+- Modify: `settings-ui/style.css`
+
+- [ ] **Step 1: Update the Shortcut field markup**
+
+In `settings-ui/index.html`, replace the current Shortcut field block (lines ~30-33):
+
+```html
+    <label class="field">
+      <span>Shortcut</span>
+      <input type="text" id="hotkey" placeholder="CmdOrCtrl+Shift+W" />
+    </label>
+```
+
+with a field+button row and a hint element:
+
+```html
+    <label class="field">
+      <span>Shortcut</span>
+      <div class="hotkey-row">
+        <input type="text" id="hotkey" placeholder="CmdOrCtrl+Shift+W" />
+        <button type="button" id="record_hotkey" class="secondary">Record</button>
+      </div>
+    </label>
+    <p id="hotkey_hint" class="hotkey-hint" hidden></p>
+```
+
+- [ ] **Step 2: Include `hotkey.js` before `main.js`**
+
+In `settings-ui/index.html`, the scripts at the bottom must load `hotkey.js` first so `window.HotkeyFmt` exists when `main.js` runs. Replace:
+
+```html
+    <script src="main.js"></script>
+```
+
+with:
+
+```html
+    <script src="hotkey.js"></script>
+    <script src="main.js"></script>
+```
+
+- [ ] **Step 3: Add styles**
+
+Append to `settings-ui/style.css`:
+
+```css
+.hotkey-row { display: flex; gap: 8px; align-items: center; }
+.hotkey-row #hotkey { flex: 1; min-width: 0; }
+#record_hotkey.recording { background: #f0a500; color: #1a1a1a; }
+.hotkey-hint { font-size: 12px; color: #f0a500; margin: 4px 0 0; }
+```
+
+- [ ] **Step 4: Verify the crate still builds (assets embed)**
+
+Run: `cd src-tauri && cargo build`
+Expected: builds (no Rust change; this confirms the embedded-asset build is unaffected). Use `dangerouslyDisableSandbox: true` (foreground) if a sandbox/permission error appears.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add settings-ui/index.html settings-ui/style.css
+git commit -m "feat(hotkey): Record button + hint markup and styles"
+```
+
+---
+
+### Task 3: Recording state machine in `main.js`
+
+**Files:**
+- Modify: `settings-ui/main.js`
+
+- [ ] **Step 1: Add the recorder logic**
+
+Append to `settings-ui/main.js` (after the existing functions, before the
+`DOMContentLoaded` handler — or anywhere at module scope):
+
+```js
+// --- Shortcut recorder ---
+
+let recordingHotkey = false;
+let hotkeyPrev = "";
+const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"]);
+
+function setHotkeyHint(msg) {
+  const hint = document.getElementById("hotkey_hint");
+  if (!msg) { hint.hidden = true; hint.textContent = ""; }
+  else { hint.textContent = msg; hint.hidden = false; }
+}
+
+function stopRecording(restore) {
+  if (!recordingHotkey) return;
+  recordingHotkey = false;
+  window.removeEventListener("keydown", onRecordKeydown, true);
+  window.removeEventListener("blur", onRecordBlur, true);
+  const btn = document.getElementById("record_hotkey");
+  btn.textContent = "Record";
+  btn.classList.remove("recording");
+  if (restore) document.getElementById("hotkey").value = hotkeyPrev;
+}
+
+function onRecordBlur() { stopRecording(true); }
+
+function onRecordKeydown(e) {
+  e.preventDefault();
+  e.stopPropagation();
+  if (MODIFIER_KEYS.has(e.key)) return;            // ignore bare modifiers
+  if (e.key === "Escape") { setHotkeyHint(""); stopRecording(true); return; }
+  const mods = { ctrl: e.ctrlKey, alt: e.altKey, shift: e.shiftKey, meta: e.metaKey };
+  const accel = window.HotkeyFmt.comboToAccelerator(mods, e.code);
+  if (accel === null) { setHotkeyHint("Unsupported key — try another."); return; }
+  if (!window.HotkeyFmt.isValidCombo(mods, e.code)) {
+    setHotkeyHint("Add a modifier (Ctrl / Alt / Shift).");
+    return;
+  }
+  document.getElementById("hotkey").value = accel;
+  setHotkeyHint("");
+  stopRecording(false);
+}
+
+function toggleRecording() {
+  if (recordingHotkey) { setHotkeyHint(""); stopRecording(true); return; }
+  recordingHotkey = true;
+  hotkeyPrev = document.getElementById("hotkey").value;
+  const btn = document.getElementById("record_hotkey");
+  btn.textContent = "Press keys… (Esc to cancel)";
+  btn.classList.add("recording");
+  setHotkeyHint("");
+  window.addEventListener("keydown", onRecordKeydown, true);
+  window.addEventListener("blur", onRecordBlur, true);
+}
+```
+
+- [ ] **Step 2: Wire the button in the existing `DOMContentLoaded` handler**
+
+In `settings-ui/main.js`, inside the existing `window.addEventListener("DOMContentLoaded", () => { ... })` handler, add:
+
+```js
+  document.getElementById("record_hotkey").addEventListener("click", toggleRecording);
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd src-tauri && cargo build`
+Expected: builds (no Rust change). (sandbox-disable foreground if needed.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add settings-ui/main.js
+git commit -m "feat(hotkey): keydown recording state machine wired to Record button"
+```
+
+---
+
+### Task 4: Surface shortcut registration failures (Rust + Save)
+
+**Files:**
+- Modify: `src-tauri/src/settings.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/commands.rs`
+- Modify: `settings-ui/main.js`
+
+- [ ] **Step 1: `settings::apply` returns the registration error**
+
+In `src-tauri/src/settings.rs`, replace the whole `apply` function:
+
+```rust
+/// Apply side effects of settings (autostart + global shortcut). Returns the global-
+/// shortcut registration error as `Some(msg)` if registering failed; `None` if it
+/// registered successfully, or the shortcut is disabled/empty, or on non-desktop.
+pub fn apply(app: &AppHandle, s: &Settings) -> Option<String> {
+    #[cfg(desktop)]
+    {
+        use tauri_plugin_autostart::ManagerExt;
+        let autostart = app.autolaunch();
+        if s.autostart {
+            let _ = autostart.enable();
+        } else {
+            let _ = autostart.disable();
+        }
+
+        use tauri_plugin_global_shortcut::GlobalShortcutExt;
+        let gs = app.global_shortcut();
+        let _ = gs.unregister_all();
+        if s.hotkey_enabled && !s.hotkey.trim().is_empty() {
+            return match gs.register(s.hotkey.as_str()) {
+                Ok(_) => None,
+                Err(e) => Some(e.to_string()),
+            };
+        }
+        None
+    }
+    #[cfg(not(desktop))]
+    {
+        let _ = (app, s);
+        None
+    }
+}
+```
+
+- [ ] **Step 2: Update the startup `apply` call in `lib.rs`**
+
+In `src-tauri/src/lib.rs`, in `setup`, the line `settings::apply(handle, &s);` now returns a value — discard it:
+
+```rust
+            let _ = settings::apply(handle, &s);
+```
+
+- [ ] **Step 3: `set_settings` returns the warning**
+
+In `src-tauri/src/commands.rs`, change `set_settings` to return `Result<Option<String>, String>` (keep the existing `is_remote` + `require_unlocked` guards):
+
+```rust
+#[tauri::command]
+pub fn set_settings(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    settings: Settings,
+) -> Result<Option<String>, String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    crate::settings::save(&app, &settings).map_err(|e| e.to_string())?;
+    Ok(crate::settings::apply(&app, &settings))
+}
+```
+
+- [ ] **Step 4: Build + test (Rust unchanged behavior, signatures compile)**
+
+Run: `cd src-tauri && cargo build && cargo test --lib`
+Expected: builds; all 45 existing tests pass. (sandbox-disable foreground if needed.)
+
+- [ ] **Step 5: `save()` shows the warning**
+
+In `settings-ui/main.js`, replace the body of `save()` from the `await invoke("set_settings"...)` line onward. The full new `save()`:
+
+```js
+async function save() {
+  const s = await invoke("get_settings");
+  for (const f of BOOLS) {
+    const el = document.getElementById(f);
+    if (el) s[f] = el.checked;
+  }
+  const hk = document.getElementById("hotkey").value.trim();
+  s.hotkey = hk || "CmdOrCtrl+Shift+W";
+  const note = document.getElementById("note");
+  try {
+    const warn = await invoke("set_settings", { settings: s });
+    if (warn) {
+      note.textContent = "Saved — shortcut not registered (may be in use): " + warn;
+      setTimeout(() => (note.textContent = ""), 6000);
+    } else {
+      note.textContent = "Saved ✓";
+      setTimeout(() => (note.textContent = ""), 1500);
+    }
+  } catch (e) {
+    note.textContent = String(e);
+  }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/settings.rs src-tauri/src/lib.rs src-tauri/src/commands.rs settings-ui/main.js
+git commit -m "feat(hotkey): surface global-shortcut registration failures on Save"
+```
+
+---
+
+### Task 5: Smoke test on Linux
+
+**Files:** none (manual verification).
+
+- [ ] **Step 1: Run the app (isolated profile so real data is untouched)**
+
+```bash
+cd "/home/karem/side projects/whatRust"
+node settings-ui/comboToAccelerator.test.mjs   # quick: formatter still green
+```
+Then launch the built binary or `cargo tauri dev`. Open Settings (tray → Settings).
+
+- [ ] **Step 2: Record a normal combo**
+- Click **Record** → button shows "Press keys… (Esc to cancel)".
+- Press **Ctrl+Shift+W** → field shows `CmdOrCtrl+Shift+W`, button returns to "Record".
+
+- [ ] **Step 3: Record a function key**
+- Click **Record**, press **F8** → field shows `F8` (no modifier needed).
+
+- [ ] **Step 4: Validation + cancel**
+- Click **Record**, press a bare letter (e.g. **A**) → hint "Add a modifier (Ctrl / Alt / Shift)", field unchanged, still recording.
+- Press **Esc** → recording cancels, field restored to its prior value.
+
+- [ ] **Step 5: Save + register**
+- With a valid combo (e.g. `CmdOrCtrl+Shift+W`) and "Enable global show/hide shortcut" on, click **Save** → "Saved ✓"; pressing the combo toggles the active window.
+- Set a likely-rejected combo (e.g. record `Shift+Space` or a combo already taken by the desktop), Save → the "Saved — shortcut not registered (may be in use): …" warning appears (and persists ~6s).
+
+- [ ] **Step 6: Final commit (if any fixups)**
+
+```bash
+git add -A && git commit -m "test(hotkey): smoke-test fixups"
+```

--- a/docs/superpowers/specs/2026-06-01-app-lock-design.md
+++ b/docs/superpowers/specs/2026-06-01-app-lock-design.md
@@ -1,0 +1,495 @@
+# whatRust App Lock — Design Spec
+
+**Date:** 2026-06-01
+**Status:** Approved (brainstorming → spec)
+**Feature:** Optional app lock with a password baseline and per-platform biometric unlock (fingerprint / Windows Hello / Touch ID).
+
+---
+
+## 1. Goal & scope
+
+Add an **optional** app lock to whatRust, enabled from Settings. When enabled, the
+app requires authentication — a **password** (always) or, where the OS supports it,
+a **biometric** unlock — before the user can see or interact with any account window.
+
+This is an **access-control / shoulder-surfing** feature, **not encryption at rest**
+(see §10). It gates the UI, not the bytes on disk.
+
+### In scope
+- Password baseline (Argon2id), works on Linux, Windows, macOS.
+- Biometric unlock as an optional shortcut: Windows Hello, macOS Touch ID, Linux polkit (fingerprint where configured).
+- Lock gate covering **all** windows (one `wa-*` per account + `settings`).
+- Lock triggers: on launch, manual "Lock now", on hide-to-tray, on idle.
+- Forgot-password recovery via session-wiping reset.
+- Settings UI section + a dedicated lock screen.
+
+### Out of scope (explicitly)
+- **Encryption at rest** of WhatsApp session/message data. Called out so the UI does
+  not imply protection it doesn't provide. May be a separate future feature.
+- Per-account locks (the lock is app-wide).
+- Cloud / synced password. The lock is local-only, no backdoor.
+
+---
+
+## 2. Research summary (grounded, adversarially verified)
+
+Full brief produced by the `biometric-applock-research` workflow (28 agents, 22
+risk-claims verified). Load-bearing conclusions:
+
+- **No drop-in plugin.** `tauri-plugin-biometric` (official) is **mobile-only**
+  (`#![cfg(mobile)]`; empty crate on desktop). `tauri-plugin-biometry` (community,
+  the "y" one) covers Windows + macOS but **not Linux**.
+- **`robius-authentication` is unsafe to use.** Shipped crates.io **0.1.1** has a Linux
+  stub: async `authenticate()` calls `unimplemented!()` (**panics**), and
+  `blocking_authenticate()` returns `Ok(())` **without verifying anything** (silent
+  false-pass). The README/callback API is an unpublished 0.2.0. Repo archived
+  2025-07-07. **Do not use.**
+- Because the user wants Linux fingerprint too, the only viable path is **per-platform
+  native code behind one Rust trait**.
+- **Every OS auth path here returns yes/no, no key material** (Windows Hello, Touch ID
+  via `DeviceOwnerAuthentication`, polkit, PAM, fprintd). It can gate the UI; it cannot
+  decrypt anything. This is why the lock is access-control, not at-rest encryption.
+
+Claim status (carried into this design):
+- **CONFIRMED:** official plugin mobile-only; Windows needs
+  `IUserConsentVerifierInterop::RequestVerificationForWindowAsync(hwnd,…)` (the UWP
+  `RequestVerificationAsync` hangs); activation **factory** required (`CoCreateInstance`
+  fails `0x80040154`); `CheckAvailabilityAsync` returns `Available` even for PIN-only;
+  `LAPolicy::DeviceOwnerAuthentication` falls back to the login password;
+  `NSFaceIDUsageDescription` not required for Touch ID; polkit `AllowUserInteraction`
+  pops the DE agent dialog (Bitwarden ships this); all gates return no key; Argon2
+  defaults = Argon2id; Tauri v2 capability scoping denies IPC to unmatched windows;
+  `argon2 0.5.3` / `objc2-local-authentication 0.3.2` versions.
+- **REFUTED:** `robius-authentication` "clean Err/None on Linux" — it panics / false-passes.
+- **UNCERTAIN (verify on hardware):** that **ad-hoc** macOS signing (`codesign -s -`) is
+  enough for `canEvaluatePolicy` / Touch ID. The in-app `LAContext` path is correct and
+  needs no Apple signing in principle, but "ad-hoc is enough" is inferred, not Apple-
+  documented. Smoke-test on a real Mac before claiming macOS support.
+
+---
+
+## 3. Architecture overview
+
+```
+                    ┌──────────────── locked? (LockState.unlocked == false) ───────────────┐
+                    │                                                                       │
+   launch ──▶ applock::load() ──▶ if enabled && lock_on_launch ──▶ lock_now()               │
+                                                                     │                      │
+   tray "Lock now" / hide-to-tray / idle-timeout ──────────────────▶ lock_now()             │
+                                                                     │                      │
+                          hide all wa-*/settings windows ; show `lock` window               │
+                                                                     │                      │
+                          lock.html ──invoke──▶ unlock(password)  ───┘                       │
+                                          └────▶ unlock_biometric()                          │
+                                          └────▶ reset_app_lock()                            │
+                                                     │ on success                            │
+                                          set unlocked = true ; close lock window ;          │
+                                          re-show previously-visible windows  ──────────────┘
+```
+
+**The security boundary lives in the Rust backend, not the window layer.** Hiding
+windows is UX only (DOM/state survive `hide()`). Tauri v2 does **not** authorize *app*
+commands per-window — that is exactly why the repo already uses `is_remote(window)`
+checks inside commands. We extend that same pattern (§6).
+
+### New / changed files
+
+| File | Change |
+|---|---|
+| `src-tauri/src/applock.rs` | **NEW.** Config struct, load/save, Argon2 hash/verify, reset logic, pure helpers + unit tests. |
+| `src-tauri/src/biometric/mod.rs` | **NEW.** `Availability` enum, trait-style `availability()` / `authenticate()` dispatch, cfg-gated to platform modules + `compile_error!()` catch-all. |
+| `src-tauri/src/biometric/windows.rs` | **NEW.** Windows Hello via `windows` crate. |
+| `src-tauri/src/biometric/macos.rs` | **NEW.** Touch ID via `objc2-local-authentication`. |
+| `src-tauri/src/biometric/linux.rs` | **NEW.** polkit via `zbus` + `zbus_polkit`. |
+| `src-tauri/src/lock.rs` | **NEW.** `LockState`, `lock_now`, `unlock`, lock-window create/show, window hide/restore, idle watcher. |
+| `src-tauri/src/commands.rs` | **EDIT.** Add lock commands; add `require_unlocked` guard to sensitive commands; suppress notification bodies while locked. |
+| `src-tauri/src/tray.rs` | **EDIT.** Add "Lock now" menu item (only when lock enabled). |
+| `src-tauri/src/lib.rs` | **EDIT.** `mod applock; mod biometric; mod lock;`, manage `LockState`, register commands, lock-on-launch in `setup`, gate `show_active`, spawn idle watcher. |
+| `src-tauri/src/window.rs` | **EDIT.** `lock_on_hide` hook in the close-to-tray handler; `show_active` defers to the lock window when locked. |
+| `src-tauri/capabilities/lock.json` | **NEW.** IPC capability for the `lock` window. |
+| `src-tauri/Cargo.toml` | **EDIT.** Add `argon2`, `rand_core`/`OsRng`; per-target `windows`, `objc2-local-authentication`/`objc2-foundation`/`block2`, `zbus`/`zbus_polkit`, `user-idle`. |
+| `src-tauri/tauri.conf.json` | **EDIT.** Bundle the polkit `.policy` file into the `.deb` (Linux); version bump. |
+| `src-tauri/resources/com.karem.whatrust.policy` | **NEW.** polkit action definition (Linux). |
+| `settings-ui/index.html` / `main.js` / `style.css` | **EDIT.** "Security" section + status wiring. |
+| `settings-ui/lock.html` / `lock.js` / `lock.css` | **NEW.** Lock screen. |
+| `README.md` | **EDIT.** App-lock section + honest at-rest caveat + per-platform notes. |
+
+---
+
+## 4. Data model & storage
+
+New module `applock.rs`, persisted to **its own** file `app-lock.json` in
+`app_config_dir()` (kept separate from `settings.json` so the password hash never
+rides along with the general settings blob).
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AppLockConfig {
+    pub enabled: bool,             // master switch
+    pub password_phc: Option<String>, // Argon2id PHC string; None when disabled
+    pub biometric_enabled: bool,   // user opted in AND it was available at enable time
+    pub lock_on_launch: bool,      // default true
+    pub lock_on_hide: bool,        // default FALSE (user decision)
+    pub idle_secs: u32,            // 0 = idle auto-lock off (default 0)
+}
+
+impl Default for AppLockConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            password_phc: None,
+            biometric_enabled: false,
+            lock_on_launch: true,
+            lock_on_hide: false,
+            idle_secs: 0,
+        }
+    }
+}
+```
+
+- `password_phc` is the self-describing Argon2id PHC string (salt embedded). **A
+  verifier is not a secret** (irreversible), so a plain file is correct — no keychain /
+  Secret Service / DPAPI needed. The `keyring` crate is intentionally **not** a
+  dependency; we would only need it if we stored a real secret (a decryption key), which
+  is out of scope.
+- `enabled` implies `password_phc.is_some()`. We never set `enabled = true` without a
+  password.
+
+**The hash never leaves the backend.** The settings/lock UIs read status through a
+dedicated command (§7) that returns booleans only — never `password_phc`.
+
+---
+
+## 5. Password — the root of trust
+
+- Crate: **`argon2 = "0.5.3"`** with `Argon2::default()` → Argon2id, version `0x13`,
+  OWASP-baseline params (m=19456 KiB, t=2, p=1). Salt via
+  `SaltString::generate(&mut OsRng)` (from `rand_core` / argon2's re-export).
+- `hash_password(pw) -> String` (PHC) and `verify_password(pw, phc) -> bool`
+  (`Argon2::default().verify_password`). Both pure, unit-tested.
+- **Set / enable:** `set_app_lock_password(new, confirm)` — requires `new == confirm`
+  and `new.chars().count() >= 4` (minimum 4 characters); stores PHC, sets
+  `enabled = true`. Allowed only from a trusted, unlocked context (settings window).
+- **Change:** `change_app_lock_password(current, new, confirm)` — verifies `current`.
+- **Disable:** `disable_app_lock(current)` — verifies `current`, then clears
+  `password_phc`, sets `enabled = false`, `biometric_enabled = false`.
+
+---
+
+## 6. The lock gate (security boundary)
+
+### 6.1 State
+```rust
+pub struct LockState {
+    pub unlocked: Mutex<bool>,        // false == locked
+    pub hidden: Mutex<Vec<String>>,   // labels hidden by lock_now, to restore on unlock
+}
+```
+Managed via `.manage(LockState::default())`. **Default `unlocked = true`** for the
+common case (lock disabled). When lock is enabled, `setup` decides the initial state
+(§8).
+
+### 6.2 `lock_now(app)`
+1. Set `unlocked = false`.
+2. Record into `hidden` every currently-visible window whose label is `wa-*` or
+   `settings`; `hide()` each.
+3. Create-or-show the `lock` window (`lock.html`) with:
+   `decorations(false)`, `always_on_top(true)`, `content_protected(true)` (blocks
+   screen capture of the lock screen), `resizable(false)`, `skip_taskbar` left default,
+   `focused(true)`. Register a `CloseRequested` handler that calls `api.prevent_close()`
+   **while locked** (the X must not relaunch into an unlocked state).
+
+### 6.3 `unlock(app)`
+1. Set `unlocked = true`.
+2. Close (destroy) the `lock` window.
+3. Re-show each label recorded in `hidden`; clear it. If `hidden` was empty (e.g. locked
+   at launch from the tray), fall back to `show_active`.
+
+### 6.4 Command authorization (the real boundary)
+Tauri v2 capability scoping governs *whether a window has IPC at all* and which
+plugin/core permissions it has — it does **not** authorize app-defined commands
+per-window. So, exactly like the existing `is_remote` checks:
+
+- `is_lock_window(&window) -> bool` ≡ `window.label() == "lock"`.
+- `require_unlocked(&app) -> Result<(), String>` → `Err("locked")` when
+  `LockState.unlocked == false`.
+
+Apply (four buckets):
+- **Lock-screen actions** (`unlock`, `unlock_biometric`, `reset_app_lock`): callable
+  **only** from the `lock` window (`is_lock_window`); these must work **while locked**,
+  so they do **not** call `require_unlocked`.
+- **Status read** (`get_lock_status` — booleans only, never the hash): callable from any
+  non-remote window (`!is_remote`), **without** `require_unlocked`, because both the lock
+  screen (while locked) and the settings window need it.
+- **Sensitive commands** (`list/add/remove/rename/open_account`, `get_settings`,
+  `set_settings`, `open_settings`, and all password/biometric config setters —
+  `set_app_lock_password`, `change_app_lock_password`, `disable_app_lock`,
+  `set_app_lock_options`, `set_biometric_enabled`): add `require_unlocked(&app)?` in
+  addition to the existing `is_remote` guard. (These all run from the unlocked settings
+  window; enabling the lock the first time happens while `unlocked == true`.)
+- `notify` / `set_unread` (from hidden `wa-*` windows in the background): still
+  processed, but `notify` **suppresses the body while locked** (§9).
+
+### 6.5 New capability — `capabilities/lock.json`
+```json
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "lock-local",
+  "description": "IPC for the app-lock screen. core:default for invoke; no remote, no account/notification perms.",
+  "windows": ["lock"],
+  "permissions": ["core:default"]
+}
+```
+The lock window needs a capability so the IPC bridge exists; `core:default` is the same
+grant the `settings` window already has. Per-command authorization is enforced in code
+(§6.4), so this capability does not widen the attack surface.
+
+---
+
+## 7. Biometric — optional shortcut to the same gate
+
+Common interface in `biometric/mod.rs`:
+```rust
+pub enum Availability { Available, NotConfigured, Unsupported }
+pub fn availability() -> Availability;            // cheap, for showing/hiding the toggle
+pub fn authenticate(reason: &str) -> Result<bool, String>; // blocking; true == verified
+```
+cfg-gated to one platform module each, with a `compile_error!()` catch-all (mirrors
+`window.rs::apply_isolation`). Biometric is a **shortcut to the same gate** — a
+successful biometric verification flips `unlocked = true` just like a correct password.
+The password always remains a working fallback. Enabling biometric requires
+`password_phc.is_some()` **and** one successful test `authenticate()` at enable time.
+
+### 7.1 Windows — Windows Hello
+- Crate: **`windows = "0.61"`** (matches Tauri 2.11.2's pinned `windows` so
+  `window.hwnd()` HWND types unify — do **not** bump to 0.62). Features:
+  `Security_Credentials_UI`, `Win32_System_WinRT`, `Win32_Foundation`, `Foundation`.
+- `availability()`: `UserConsentVerifier::CheckAvailabilityAsync()?.get()?` →
+  `Available` (note: `Available` even for PIN-only — acceptable, it's still a consent
+  gate).
+- `authenticate()`: get the active window HWND; obtain the interop factory via
+  `windows::core::factory::<UserConsentVerifier, IUserConsentVerifierInterop>()`
+  (**not** `CoCreateInstance`, which fails `0x80040154`); call
+  `RequestVerificationForWindowAsync(hwnd, &HSTRING::from(reason))?.get()?` and map
+  `Verified` → `true`. **Must** call `CheckAvailabilityAsync` first (skipping it makes
+  the verification hang). Call from a COM-initialized thread. The prompt may open behind
+  the window → apply a focus/foreground nudge. Win11 build 22000+ only (older →
+  `Unsupported`).
+
+### 7.2 macOS — Touch ID
+- Crates: **`objc2-local-authentication = "0.3.2"`**, `objc2-foundation`, `block2`.
+- `availability()`: fresh `LAContext`, `canEvaluatePolicy(LAPolicy::DeviceOwnerAuthenticationWithBiometrics)`
+  to know if Touch ID hardware is present/enrolled (else `NotConfigured`).
+- `authenticate()`: fresh `LAContext` (it caches success — never reuse), `evaluatePolicy`
+  with **`LAPolicy::DeviceOwnerAuthentication`** (Touch ID **or** login-password
+  fallback). The reply block runs on a **background thread** → bridge to sync via a
+  `std::sync::mpsc` (or oneshot) channel. `localizedReason` must be **non-empty** (empty
+  → ObjC exception → process abort). `NSFaceIDUsageDescription` not required (Touch ID,
+  not Face ID). Keep `hardenedRuntime = true`. **Verify on real Mac hardware** that
+  ad-hoc signing suffices (the one UNCERTAIN claim).
+
+### 7.3 Linux — polkit
+- Crates: **`zbus`**, **`zbus_polkit = "5.0.0"`**.
+- Ship a polkit action file `com.karem.whatrust.unlock` to
+  `/usr/share/polkit-1/actions/` (installed by the `.deb`; needs root **at install
+  time**, not runtime). `<defaults>` use `auth_self` (authenticate as the current user;
+  the DE's agent offers fingerprint where `pam_fprintd` is configured).
+- `authenticate()`: `Connection::system()` (the **system** bus, not session); build the
+  `Subject` from the current process; `Authority::check_authorization` with the
+  `ALLOW_USER_INTERACTION` flag → pops the desktop's native polkit dialog; map
+  `authorized == true` → `true`.
+- `availability()`: `Available` if the polkit `Authority` is reachable on the system bus
+  **and** the action is registered; otherwise `NotConfigured`. Realistically the system
+  bus is reachable on native `.deb` installs; **Flatpak/Snap sandboxing breaks system-
+  bus access**, and **AppImage never installs the `.policy`** → both report
+  `NotConfigured` and the user uses the password (which always works). This best-effort
+  posture is stated honestly in the UI and README.
+
+---
+
+## 8. Triggers
+
+Each trigger is an independent toggle. Defaults when the lock is enabled:
+`lock_on_launch = true`, `lock_on_hide = false`, `idle_secs = 0` (off). "Lock now" is an
+always-available action, not a toggle.
+
+- **On launch** (`setup`): if `enabled && lock_on_launch`, start with
+  `unlocked = false`. Account windows still open (hidden) so background WhatsApp keeps
+  delivering unread counts; the `lock` window is shown — **unless** the app launched
+  with `--minimized` / `start_minimized`, in which case stay locked in the tray and show
+  the lock window only on first reveal.
+- **Manual "Lock now"** (`tray.rs`): a menu item shown only when `enabled`; calls
+  `lock_now`.
+- **On hide-to-tray** (`window.rs` close handler): when `enabled && lock_on_hide`, the
+  close-to-tray path calls `lock_now` instead of a plain `hide()`.
+- **On idle** (`lib.rs`): if `idle_secs > 0`, spawn a watcher (the **`user-idle`** crate)
+  that polls system idle time on an interval and calls `lock_now` when it crosses the
+  threshold. **Wayland caveat:** idle is under-reported on Wayland (may need the crate's
+  `dbus` feature, or fall back to focus-based timing); documented, and mitigated by the
+  off-by-default.
+
+`show_active` (and the global-shortcut toggle, single-instance, macOS Reopen) must
+defer to the lock window when `unlocked == false`: a reveal request shows/focuses the
+`lock` window, never an account window.
+
+---
+
+## 9. Notifications & badge while locked
+
+- **While locked, suppress notification bodies.** `notify` checks `LockState`; when
+  locked it shows **nothing** (default) — no message preview leaks to the OS
+  notification center or a lock screen. (Conservative default chosen with the user;
+  could be relaxed to a generic "New message" title later.)
+- **Keep the unread count badge.** `set_unread` continues to update the aggregate tray
+  badge (a number only — no content), so the tray still reflects activity while locked.
+
+---
+
+## 10. Honest security framing (UI + README + this spec)
+
+State plainly, everywhere the feature is described:
+
+> App lock controls who can open whatRust's windows. It does **not** encrypt your data.
+> Your WhatsApp session stays readable on disk to other software running as your user
+> and to anyone with raw disk access, whether the app is locked or not.
+
+- This matches Signal Desktop's posture ("at-rest encryption is not something Signal
+  Desktop has ever claimed to provide").
+- OS key stores wouldn't change this: DPAPI/`safeStorage` don't isolate same-user apps;
+  the biometric/polkit/PAM gates return no key.
+- Real at-rest protection = OS full-disk encryption (FileVault / BitLocker / LUKS), or a
+  future feature where whatRust encrypts its data files with an Argon2-derived key — **out
+  of scope here**, and the lock UI must not imply it.
+
+---
+
+## 11. Recovery — forgot password
+
+A local lock has **no backdoor**. The lock screen offers **"Forgot password? Reset"**:
+- Confirm dialog explaining it logs out **all** accounts.
+- `reset_app_lock(app)` (callable only from the `lock` window): delete every account
+  profile dir + the default webview store data + `accounts.json` + `app-lock.json`, then
+  relaunch the app fresh (single `default` account, logged out, lock disabled).
+- Security property: a thief who hits Reset gets an empty, logged-out app — no message
+  access. Recovery and security are both satisfied because the data was only **gated**,
+  not encrypted.
+- Reset must reuse the existing `accounts::delete_profile` / profile-dir logic so paths
+  stay correct. The pure path-selection logic is unit-tested against tmp dirs.
+
+---
+
+## 12. Settings & lock UIs
+
+### 12.1 Settings — new "Security" section (`index.html` / `main.js`)
+- **Enable app lock** → reveals password ×2 fields → `set_app_lock_password`.
+- **Use biometric** toggle — rendered only when `availability() == Available`; label is
+  per-OS ("Use Windows Hello" / "Use Touch ID" / "Use system authentication
+  (fingerprint)"). Toggling on runs a test `authenticate()` first.
+- **Trigger toggles:** lock on launch · lock on hide to tray · auto-lock when idle for
+  [N] minutes (number input; 0/empty = off).
+- **Lock now** button.
+- **Disable app lock** → prompts for current password → `disable_app_lock`.
+- The honest one-liner from §10, shown inline.
+- All wired via a dedicated **`get_lock_status`** command returning
+  `{ enabled, biometric_available, biometric_enabled, lock_on_launch, lock_on_hide,
+  idle_secs }` — **never** the hash.
+
+### 12.2 Lock screen (`lock.html` / `lock.js` / `lock.css`)
+- App icon + title, password field, **Unlock** button.
+- **Biometric** button when `biometric_enabled` — auto-triggers `unlock_biometric()` on
+  load and offers a retry button.
+- **"Forgot password? Reset"** link → confirm → `reset_app_lock`.
+- Minimal, focused; RTL-friendly (project convention); inherits the existing style.
+
+---
+
+## 13. Cargo dependencies (additive)
+
+```toml
+[dependencies]
+argon2 = "0.5.3"            # Argon2id password hashing (PHC strings)
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = "5"                 # system-bus client (zbus_polkit 5.0.0 requires zbus 5.x)
+zbus_polkit = "5.0.0"      # polkit Authority.CheckAuthorization
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = [
+  "Security_Credentials_UI", "Win32_System_WinRT", "Win32_Foundation", "Foundation",
+] }                         # MUST match Tauri 2.11.2's windows version (HWND unify)
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-local-authentication = "0.3.2"
+objc2-foundation = "0.3"   # NSString/reason
+block2 = "..."             # evaluatePolicy reply block
+
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+user-idle = "0.6"          # idle-timeout trigger (Wayland caveat documented)
+```
+Exact `zbus`/`block2`/`user-idle` patch versions resolved during implementation against
+the pinned tree. Version bump in `Cargo.toml` / `tauri.conf.json` / `Cargo.lock` at
+release (post-implementation), not in this design.
+
+---
+
+## 14. Testing strategy
+
+**Unit (pure, in-module `#[cfg(test)]`):**
+- `applock`: hash→verify roundtrip; wrong password fails; PHC is Argon2id; config serde
+  defaults (`lock_on_launch=true`, `lock_on_hide=false`, `idle_secs=0`); partial-JSON
+  fill; `enabled` never true without a hash.
+- `lock`: `require_unlocked` / `is_lock_window` predicates; hide/restore label
+  bookkeeping (pure list logic).
+- recovery: path-selection deletes exactly the expected set (account profiles + default
+  store + accounts.json + app-lock.json) against tmp dirs — never touches anything else.
+- `biometric`: `Availability` mapping for the pure branches; per-OS `availability()`
+  error→`Unsupported`/`NotConfigured` mapping where testable without hardware.
+- idle: threshold-crossing decision is a pure function of (idle_secs, elapsed).
+
+**Smoke (manual, `cargo tauri dev` on Linux — the dev target):**
+- Enable lock, set password, lock-now → all windows hide, lock screen shows.
+- Wrong password rejected; correct password unlocks and restores windows.
+- On-launch lock; hide-to-tray (toggle on); idle (set a short timeout).
+- polkit dialog appears on a `.deb`-installed build with a polkit agent; password
+  fallback when polkit is unavailable.
+- Reset wipes sessions → fresh logged-out app.
+- Verify a hidden `wa-*` window cannot reach account/settings commands while locked
+  (the `require_unlocked` boundary).
+
+**Hardware-pending (flagged, not blocking the Linux release):**
+- Windows Hello prompt + fallback on Win11 22000+.
+- Touch ID prompt + login-password fallback on a Mac; confirm ad-hoc signing suffices.
+
+---
+
+## 15. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Lock can be bypassed by force-showing a hidden window | The boundary is the in-command `require_unlocked` guard, not window visibility. |
+| Lock window X relaunches unlocked | `prevent_close` while locked. |
+| Message preview leaks on lock screen | Suppress notification bodies while locked (§9). |
+| `windows` 0.62 HWND mismatch with Tauri 0.61 | Pin `windows = 0.61`. |
+| macOS empty `localizedReason` → process abort | Always pass a non-empty reason. |
+| macOS ad-hoc signing insufficient | Flagged UNCERTAIN; verify on hardware before claiming macOS support. |
+| Linux: polkit unavailable (AppImage/Flatpak/Snap/no agent) | Best-effort; password always works; stated honestly. |
+| User forgets password | Reset = wipe sessions, no data loss beyond logout. |
+| User thinks lock = encryption | Explicit honest framing in UI/README/spec (§10). |
+
+---
+
+## 16. Build order (for the implementation plan)
+
+1. `applock.rs` — config + Argon2 + tests (no UI yet).
+2. `lock.rs` — `LockState`, `lock_now`/`unlock`, lock-window create/hide/restore.
+3. `capabilities/lock.json` + `lock.html`/`lock.js`/`lock.css` (password-only unlock).
+4. Command guards (`require_unlocked` / `is_lock_window`) + lock commands; wire
+   `setup` lock-on-launch + `show_active` deferral.
+5. Triggers: tray "Lock now", `lock_on_hide` hook, idle watcher.
+6. Notifications-while-locked suppression.
+7. Settings "Security" section + `get_lock_status`.
+8. `biometric/` — Linux polkit first (dev target), then Windows, then macOS; wire
+   `unlock_biometric` + enable-time test + UI toggle.
+9. Recovery (`reset_app_lock`) + lock-screen reset link.
+10. README + honest framing; smoke test on Linux.

--- a/docs/superpowers/specs/2026-06-01-shortcut-recorder-design.md
+++ b/docs/superpowers/specs/2026-06-01-shortcut-recorder-design.md
@@ -1,0 +1,199 @@
+# whatRust Shortcut Recorder — Design Spec
+
+**Date:** 2026-06-01
+**Status:** Approved (brainstorming → spec)
+**Branch:** builds on `feat/app-lock`
+**Feature:** Set the global show/hide shortcut by **pressing the key combo** ("record"), instead of typing the Tauri accelerator string by hand.
+
+---
+
+## 1. Goal & scope
+
+whatRust has one global show/hide shortcut, configured today by typing an accelerator
+string (e.g. `CmdOrCtrl+Shift+W`) into a text field in Settings. This feature adds a
+**Record** button: click it, press your combo, and it's captured and written into the
+field in the correct accelerator format. It also surfaces shortcut **registration
+failures**, which are currently swallowed.
+
+### In scope
+- A "Record" button beside the existing `#hotkey` field (the field stays, editable).
+- Capture a key combo in the trusted settings webview and convert it to Tauri's
+  accelerator syntax.
+- Validation: accept a combo only if it has ≥1 modifier, or the key is a function key.
+- Surface register failures on Save (instead of silently ignoring them).
+
+### Out of scope
+- Multiple shortcuts, per-account shortcuts, or in-app (non-global) shortcuts.
+- Changing what the shortcut does (it still toggles show/hide of the active account).
+- A native OS-level key recorder (we capture in the webview).
+
+### Current state (what we build on)
+- `settings-ui/index.html:30-33` — `<input type="text" id="hotkey" …>`.
+- `settings-ui/main.js` — `load()` reads `s.hotkey` into the field; `save()` writes the
+  field back to `s.hotkey` and calls `set_settings`.
+- `src-tauri/src/settings.rs::apply` — on desktop, `gs.unregister_all()` then, if
+  `hotkey_enabled` and non-empty, `let _ = gs.register(s.hotkey.as_str())` — **the
+  register result is discarded.** `apply` returns `()`.
+- `settings.rs::Settings.hotkey` defaults to `"CmdOrCtrl+Shift+W"`.
+
+---
+
+## 2. Recording UX (`index.html`, `main.js`, `style.css`)
+
+- Wrap the existing Shortcut field and a new **`#record_hotkey`** button in a row.
+- **Idle → recording:** clicking Record sets a `recording` flag, changes the button
+  label to `Press keys… (Esc to cancel)`, remembers the field's prior value, and adds a
+  **capture-phase** `keydown` listener on `window` that calls `preventDefault()` +
+  `stopPropagation()` on every event while recording (so the combo can't trigger save,
+  navigation, or anything else).
+- **On `keydown` while recording:**
+  - If the key is a bare modifier (`Control`/`Shift`/`Alt`/`Meta`) → ignore, keep
+    waiting.
+  - If `event.key === "Escape"` → cancel: restore the prior field value, exit recording.
+  - Otherwise it's a candidate combo: build the accelerator from the modifier flags +
+    `event.code` (§3) and validate (§4).
+    - Valid → write it into `#hotkey`, exit recording.
+    - Invalid (no modifier and not a function key) → show inline hint
+      `Add a modifier (Ctrl / Alt / Shift)`, stay in recording.
+    - Unmapped key → show inline hint `Unsupported key — try another`, stay in recording.
+- **Exit recording** (any path): remove the listener, restore the button label
+  (`Record`), clear the `recording` flag. Also exit/cancel on the settings window losing
+  focus (`blur`) so a half-recorded state can't get stuck.
+- Recording only fills the field; the user clicks **Save** to persist (unchanged flow).
+
+---
+
+## 3. Accelerator formatting — pure function `comboToAccelerator(mods, code)`
+
+Pure, side-effect-free, testable. Input: `mods = {ctrl, alt, shift, meta}` (booleans)
+and `code` (a `KeyboardEvent.code` string). Output: a Tauri accelerator string, or
+`null` if the key is unmapped.
+
+Use **`event.code`** (physical key), NOT `event.key` — so `Shift+1` records as `Shift+1`,
+not `Shift+!`, independent of keyboard layout.
+
+**Modifier tokens, emitted in this stable order:**
+| Flag | Token | Notes |
+|---|---|---|
+| `ctrl` | `CmdOrCtrl` | Portable — maps to Cmd on macOS, Ctrl elsewhere (matches the default). |
+| `alt` | `Alt` | |
+| `shift` | `Shift` | |
+| `meta` | `Super` | The Super/Win/Command key. |
+
+**Key mapping (`event.code` → token):**
+| `code` pattern | Token |
+|---|---|
+| `KeyA`…`KeyZ` | `A`…`Z` (strip `Key`) |
+| `Digit0`…`Digit9` | `0`…`9` (strip `Digit`) |
+| `F1`…`F24` | `F1`…`F24` (used as-is) |
+| `ArrowUp/Down/Left/Right` | `Up/Down/Left/Right` |
+| `Space` | `Space` |
+| anything else | `null` (→ "unsupported key" hint) |
+
+Result = modifiers (in order) + key, joined with `+`. Example: `{ctrl:true, shift:true}`
++ `KeyW` → `CmdOrCtrl+Shift+W`. `{}` + `F8` → `F8`.
+
+---
+
+## 4. Validation rule
+
+A built accelerator is **accepted** iff:
+- it has at least one modifier (`ctrl || alt || shift || meta`), **or**
+- the key is a function key (`code` matches `^F([1-9]|1[0-9]|2[0-4])$`).
+
+Otherwise it is **rejected** in the UI (inline hint, stay recording). Per the user's
+choice, **Shift counts as a modifier** — so `Shift+W` passes UI validation. Note that
+some OSes reject Shift-only global shortcuts at *registration* time; that path is handled
+by §5 (the register-failure warning), so the UI doesn't need to second-guess it.
+
+---
+
+## 5. Register-failure feedback (`settings.rs`, `commands.rs`, `main.js`)
+
+Today `apply` discards the register result. Change the plumbing so Save can report it:
+
+- `settings::apply` → **`pub fn apply(app: &AppHandle, s: &Settings) -> Option<String>`**.
+  Keep the autostart side effect. For the shortcut: `unregister_all()`, then if enabled +
+  non-empty, `match gs.register(s.hotkey.as_str()) { Ok(_) => None, Err(e) => Some(e.to_string()) }`.
+  If the shortcut is disabled/empty, return `None`. On `#[cfg(not(desktop))]`, return `None`.
+- `commands::set_settings` → return **`Result<Option<String>, String>`**: after `save`,
+  return `Ok(crate::settings::apply(&app, &settings))`. (Keep the `is_remote` +
+  `require_unlocked` guards exactly as they are.)
+- `lib.rs` `setup` calls `settings::apply(handle, &s)` at startup — change to
+  `let _ = settings::apply(handle, &s);` (ignore the result there).
+- `main.js` `save()`: `const warn = await invoke("set_settings", { settings: s });`
+  then `note.textContent = warn ? ("Saved — shortcut not registered (may be in use): " + warn) : "Saved ✓";`
+  Timing: the plain "Saved ✓" auto-clears after the existing 1.5s; the warning is left
+  visible for **6s** (longer, so the user actually reads it).
+
+---
+
+## 6. Files
+
+| File | Change |
+|---|---|
+| `settings-ui/index.html` | Wrap `#hotkey` + a new `#record_hotkey` button in a row; add a `#hotkey_hint` element for inline hints. |
+| `settings-ui/main.js` | `comboToAccelerator` (pure), recording state machine, button wiring; `save()` handles the `set_settings` warning return. |
+| `settings-ui/style.css` | Row layout for field+button; a `.recording` button style; `#hotkey_hint` style. |
+| `src-tauri/src/settings.rs` | `apply` returns `Option<String>` (the register error). |
+| `src-tauri/src/commands.rs` | `set_settings` returns `Result<Option<String>, String>`. |
+| `src-tauri/src/lib.rs` | startup `apply` call ignores the return. |
+| `settings-ui/comboToAccelerator.test.mjs` | **NEW** — a tiny `node` assertion script for the pure formatter. |
+
+To make `comboToAccelerator` testable in `node` without a DOM or a bundler (the project
+has no build step), and to avoid a drifting duplicate of the logic, it lives in **one
+place**: `settings-ui/hotkey.js`. That file defines `comboToAccelerator(mods, code)`,
+`isValidCombo(mods, code)`, and the function-key regex, and assigns them to
+**`globalThis.HotkeyFmt`** (it must NOT reference `window`, which is undefined in node).
+In the browser `globalThis === window`, so the page reads them as `window.HotkeyFmt`
+after `<script src="hotkey.js">` (included before `main.js`); in node the test reads the
+same `globalThis.HotkeyFmt`. One source, consumed by both — no aliasing, no duplication.
+
+---
+
+## 7. Error handling & edge cases
+
+- Capture-phase `preventDefault`/`stopPropagation` while recording → the combo never
+  leaks to other handlers (no accidental Save on Enter, no page scroll on Space/arrows).
+- Bare modifiers ignored; Esc cancels; window `blur` cancels (no stuck state).
+- Unmapped key → hint, stay recording (don't write a broken value).
+- Invalid (no modifier, not F-key) → hint, stay recording.
+- Register failure → non-blocking warning on Save; the value is still saved (the user can
+  retry a different combo). Disabling the shortcut (`hotkey_enabled` off) → `apply`
+  returns `None`, no warning.
+- Only one recording session at a time (the button is the only entry point; re-clicking
+  while recording cancels/restarts — define as: re-click cancels back to idle).
+
+---
+
+## 8. Testing
+
+- **`comboToAccelerator` / `isValidCombo`** — pure; covered by `comboToAccelerator.test.mjs`
+  run with `node settings-ui/comboToAccelerator.test.mjs` (exit non-zero on failure).
+  Cases: `Ctrl+Shift+W → CmdOrCtrl+Shift+W`; bare `F8 → F8` (valid, no modifier);
+  `Digit1`+Shift `→ Shift+1` (code-based, not `!`); `Meta`+`KeyK` `→ Super+K`; bare
+  `KeyW` → built string `W` but `isValidCombo` false; unmapped `Comma` → `null`; modifier
+  order is stable (`Ctrl+Alt+Shift+KeyP → CmdOrCtrl+Alt+Shift+P`).
+- **Rust** — the `apply`/`set_settings` signature change compiles and the existing 45
+  tests still pass. (No new Rust unit test: the register result needs a live `AppHandle`
+  / OS shortcut service; covered by smoke.)
+- **Smoke (Linux, `cargo tauri dev` or built binary)** — open Settings: Record →
+  `Ctrl+Shift+W` fills `CmdOrCtrl+Shift+W`; Record → `F8` fills `F8`; Record → bare `A`
+  shows the modifier hint and doesn't fill; Esc cancels and restores; Save with a valid
+  combo → "Saved ✓" and the global shortcut toggles the window; Save with a deliberately
+  bogus/again-registered combo → the "shortcut not registered" warning appears.
+
+---
+
+## 9. Build order (for the implementation plan)
+
+1. `settings-ui/hotkey.js` — `comboToAccelerator` + `isValidCombo` + function-key regex
+   (assigned to `globalThis.HotkeyFmt`; read as `window.HotkeyFmt` in the page).
+2. `settings-ui/comboToAccelerator.test.mjs` — node assertion script; make it pass.
+3. `index.html` — field+button row + hint element; include `hotkey.js` before `main.js`.
+4. `main.js` — recording state machine wired to the button using `window.HotkeyFmt`.
+5. `settings.rs` `apply` → `Option<String>`; `lib.rs` startup call ignores it.
+6. `commands.rs` `set_settings` → `Result<Option<String>, String>`; `main.js` `save()`
+   shows the warning.
+7. `style.css` — row + recording + hint styles.
+8. Smoke test on Linux.

--- a/settings-ui/comboToAccelerator.test.mjs
+++ b/settings-ui/comboToAccelerator.test.mjs
@@ -1,0 +1,34 @@
+// Zero-dependency assertion script for the pure hotkey formatter.
+// Run: node settings-ui/comboToAccelerator.test.mjs   (exit non-zero on failure)
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// hotkey.js assigns globalThis.HotkeyFmt; run it in this global scope.
+(0, eval)(readFileSync(join(here, "hotkey.js"), "utf8"));
+const { comboToAccelerator, isValidCombo } = globalThis.HotkeyFmt;
+
+let failures = 0;
+function eq(actual, expected, label) {
+  const a = JSON.stringify(actual), e = JSON.stringify(expected);
+  if (a !== e) { console.error(`FAIL ${label}: got ${a}, want ${e}`); failures++; }
+  else { console.log(`ok   ${label}`); }
+}
+const M = (o = {}) => ({ ctrl: false, alt: false, shift: false, meta: false, ...o });
+
+eq(comboToAccelerator(M({ ctrl: true, shift: true }), "KeyW"), "CmdOrCtrl+Shift+W", "Ctrl+Shift+W");
+eq(comboToAccelerator(M(), "F8"), "F8", "bare F8");
+eq(comboToAccelerator(M({ shift: true }), "Digit1"), "Shift+1", "Shift+Digit1 stays 1 (code-based)");
+eq(comboToAccelerator(M({ meta: true }), "KeyK"), "Super+K", "Meta+K -> Super+K");
+eq(comboToAccelerator(M({ ctrl: true, alt: true, shift: true }), "KeyP"), "CmdOrCtrl+Alt+Shift+P", "modifier order");
+eq(comboToAccelerator(M({ ctrl: true }), "ArrowUp"), "CmdOrCtrl+Up", "Ctrl+ArrowUp -> CmdOrCtrl+Up");
+eq(comboToAccelerator(M(), "Comma"), null, "unmapped key -> null");
+
+eq(isValidCombo(M(), "KeyW"), false, "bare letter invalid");
+eq(isValidCombo(M({ shift: true }), "KeyW"), true, "Shift+letter valid (Shift counts)");
+eq(isValidCombo(M(), "F8"), true, "bare F-key valid");
+eq(isValidCombo(M({ ctrl: true }), "KeyW"), true, "Ctrl+letter valid");
+
+if (failures) { console.error(`\n${failures} failing assertion(s)`); process.exit(1); }
+console.log("\nall hotkey tests passed");

--- a/settings-ui/hotkey.js
+++ b/settings-ui/hotkey.js
@@ -1,0 +1,43 @@
+// Pure helpers: turn a captured key combo into a Tauri accelerator string.
+// Assigned to globalThis.HotkeyFmt so the page (window.HotkeyFmt, since
+// window === globalThis in a browser) and the node test share ONE source.
+// MUST NOT reference `window` (undefined under node).
+(function () {
+  const FN_KEY = /^F([1-9]|1[0-9]|2[0-4])$/;
+
+  function keyToken(code) {
+    if (/^Key[A-Z]$/.test(code)) return code.slice(3);   // KeyW -> W
+    if (/^Digit[0-9]$/.test(code)) return code.slice(5); // Digit1 -> 1
+    if (FN_KEY.test(code)) return code;                  // F8 -> F8
+    switch (code) {
+      case "ArrowUp": return "Up";
+      case "ArrowDown": return "Down";
+      case "ArrowLeft": return "Left";
+      case "ArrowRight": return "Right";
+      case "Space": return "Space";
+      default: return null;                              // unmapped
+    }
+  }
+
+  // mods: {ctrl, alt, shift, meta}; code: KeyboardEvent.code.
+  // Returns the accelerator string, or null if the key is unmapped.
+  function comboToAccelerator(mods, code) {
+    const key = keyToken(code);
+    if (key === null) return null;
+    const parts = [];
+    if (mods.ctrl) parts.push("CmdOrCtrl");
+    if (mods.alt) parts.push("Alt");
+    if (mods.shift) parts.push("Shift");
+    if (mods.meta) parts.push("Super");
+    parts.push(key);
+    return parts.join("+");
+  }
+
+  // Accept only if there is a modifier, or the key itself is a function key.
+  function isValidCombo(mods, code) {
+    if (mods.ctrl || mods.alt || mods.shift || mods.meta) return true;
+    return FN_KEY.test(code);
+  }
+
+  globalThis.HotkeyFmt = { comboToAccelerator, isValidCombo, FN_KEY };
+})();

--- a/settings-ui/index.html
+++ b/settings-ui/index.html
@@ -32,6 +32,35 @@
       <input type="text" id="hotkey" placeholder="CmdOrCtrl+Shift+W" />
     </label>
 
+    <hr class="divider" />
+    <h2 class="section-title">Security</h2>
+
+    <div id="lock-disabled">
+      <label class="field"><span>App-lock password (min 4 characters)</span>
+        <input type="password" id="lock_pw1" autocomplete="new-password" /></label>
+      <label class="field"><span>Confirm password</span>
+        <input type="password" id="lock_pw2" autocomplete="new-password" /></label>
+      <button id="enable_lock">Enable app lock</button>
+    </div>
+
+    <div id="lock-enabled" hidden>
+      <label class="row" id="biometric_row" hidden>
+        <input type="checkbox" id="biometric_enabled" /> <span id="biometric_label">Use biometric</span>
+      </label>
+      <label class="row"><input type="checkbox" id="lock_on_launch" /> <span>Lock on launch</span></label>
+      <label class="row"><input type="checkbox" id="lock_on_hide" /> <span>Lock when hidden to tray</span></label>
+      <label class="field"><span>Auto-lock when idle (minutes, 0 = off)</span>
+        <input type="number" id="idle_min" min="0" step="1" value="0" /></label>
+      <div class="actions">
+        <button id="lock_now">Lock now</button>
+        <button id="change_pw" class="secondary">Change password…</button>
+        <button id="disable_lock" class="secondary">Disable…</button>
+      </div>
+    </div>
+
+    <p class="lock-note">App lock controls who can open whatRust's windows. It does
+      <strong>not</strong> encrypt your data on disk.</p>
+
     <div class="actions">
       <button id="save">Save</button>
       <span id="note" class="note"></span>

--- a/settings-ui/index.html
+++ b/settings-ui/index.html
@@ -29,8 +29,12 @@
 
     <label class="field">
       <span>Shortcut</span>
-      <input type="text" id="hotkey" placeholder="CmdOrCtrl+Shift+W" />
+      <div class="hotkey-row">
+        <input type="text" id="hotkey" placeholder="CmdOrCtrl+Shift+W" />
+        <button type="button" id="record_hotkey" class="secondary">Record</button>
+      </div>
     </label>
+    <p id="hotkey_hint" class="hotkey-hint" hidden></p>
 
     <hr class="divider" />
     <h2 class="section-title">Security</h2>
@@ -66,6 +70,7 @@
       <span id="note" class="note"></span>
     </div>
 
+    <script src="hotkey.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/settings-ui/lock.css
+++ b/settings-ui/lock.css
@@ -1,0 +1,42 @@
+:root { color-scheme: light dark; }
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: #0b141a;
+  color: #e9edef;
+}
+.lock-card {
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 28px;
+  text-align: center;
+}
+.lock-glyph { font-size: 44px; }
+h1 { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+input[type="password"] {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #2a3942;
+  background: #202c33;
+  color: #e9edef;
+  font-size: 15px;
+}
+button {
+  padding: 10px 12px;
+  border: none;
+  border-radius: 8px;
+  background: #00a884;
+  color: #fff;
+  font-size: 15px;
+  cursor: pointer;
+}
+button.secondary { background: #2a3942; }
+.error { color: #f15c6d; min-height: 1.2em; margin: 0; font-size: 13px; }
+.reset { color: #8696a0; font-size: 13px; text-decoration: none; margin-top: 8px; }
+.reset:hover { text-decoration: underline; }

--- a/settings-ui/lock.html
+++ b/settings-ui/lock.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>whatRust — Locked</title>
+    <link rel="stylesheet" href="lock.css" />
+  </head>
+  <body>
+    <div class="lock-card">
+      <div class="lock-glyph" aria-hidden="true">🔒</div>
+      <h1>whatRust is locked</h1>
+      <input type="password" id="password" placeholder="Password" autocomplete="current-password" />
+      <button id="unlock">Unlock</button>
+      <button id="biometric" class="secondary" hidden>Use biometric</button>
+      <p id="error" class="error" role="alert"></p>
+      <a id="reset" href="#" class="reset">Forgot password? Reset…</a>
+    </div>
+    <script src="lock.js"></script>
+  </body>
+</html>

--- a/settings-ui/lock.html
+++ b/settings-ui/lock.html
@@ -10,7 +10,7 @@
     <div class="lock-card">
       <div class="lock-glyph" aria-hidden="true">🔒</div>
       <h1>whatRust is locked</h1>
-      <input type="password" id="password" placeholder="Password" autocomplete="current-password" />
+      <input type="password" id="password" placeholder="Password" autocomplete="current-password" aria-label="Password" />
       <button id="unlock">Unlock</button>
       <button id="biometric" class="secondary" hidden>Use biometric</button>
       <p id="error" class="error" role="alert"></p>

--- a/settings-ui/lock.js
+++ b/settings-ui/lock.js
@@ -1,0 +1,65 @@
+const invoke = window.__TAURI__.core.invoke;
+const pwd = document.getElementById("password");
+const errEl = document.getElementById("error");
+
+async function tryUnlock() {
+  const password = pwd.value;
+  if (!password) return;
+  errEl.textContent = "";
+  try {
+    const ok = await invoke("unlock_password", { password });
+    if (!ok) {
+      errEl.textContent = "Wrong password.";
+      pwd.value = "";
+      pwd.focus();
+    }
+  } catch (e) {
+    errEl.textContent = String(e);
+  }
+}
+
+async function tryBiometric() {
+  errEl.textContent = "";
+  try {
+    const ok = await invoke("unlock_biometric");
+    if (!ok) errEl.textContent = "Biometric authentication failed — enter your password.";
+  } catch (e) {
+    errEl.textContent = String(e);
+  }
+}
+
+async function init() {
+  document.getElementById("unlock").addEventListener("click", tryUnlock);
+  pwd.addEventListener("keydown", (e) => { if (e.key === "Enter") tryUnlock(); });
+
+  const bio = document.getElementById("biometric");
+  bio.addEventListener("click", tryBiometric);
+
+  document.getElementById("reset").addEventListener("click", async (e) => {
+    e.preventDefault();
+    const ok = confirm(
+      "Reset whatRust?\n\nThis logs out ALL accounts and removes the app lock. " +
+      "You will need to re-scan the WhatsApp QR code. Your chats stay on your phone."
+    );
+    if (!ok) return;
+    try {
+      await invoke("reset_app_lock");
+    } catch (err) {
+      errEl.textContent = String(err);
+    }
+  });
+
+  try {
+    const s = await invoke("get_lock_status");
+    if (s.biometric_enabled) {
+      bio.textContent = "Use " + s.biometric_label;
+      bio.hidden = false;
+      tryBiometric(); // auto-prompt on load
+    }
+  } catch (_) {
+    // status unavailable — password still works
+  }
+  pwd.focus();
+}
+
+window.addEventListener("DOMContentLoaded", init);

--- a/settings-ui/lock.js
+++ b/settings-ui/lock.js
@@ -2,9 +2,15 @@ const invoke = window.__TAURI__.core.invoke;
 const pwd = document.getElementById("password");
 const errEl = document.getElementById("error");
 
+let busy = false;
+
 async function tryUnlock() {
+  if (busy) return;
   const password = pwd.value;
-  if (!password) return;
+  if (!password) { errEl.textContent = "Enter your password."; return; }
+  busy = true;
+  document.getElementById("unlock").disabled = true;
+  document.getElementById("biometric").disabled = true;
   errEl.textContent = "";
   try {
     const ok = await invoke("unlock_password", { password });
@@ -15,16 +21,28 @@ async function tryUnlock() {
     }
   } catch (e) {
     errEl.textContent = String(e);
+  } finally {
+    busy = false;
+    document.getElementById("unlock").disabled = false;
+    document.getElementById("biometric").disabled = false;
   }
 }
 
 async function tryBiometric() {
+  if (busy) return;
+  busy = true;
+  document.getElementById("unlock").disabled = true;
+  document.getElementById("biometric").disabled = true;
   errEl.textContent = "";
   try {
     const ok = await invoke("unlock_biometric");
     if (!ok) errEl.textContent = "Biometric authentication failed — enter your password.";
   } catch (e) {
     errEl.textContent = String(e);
+  } finally {
+    busy = false;
+    document.getElementById("unlock").disabled = false;
+    document.getElementById("biometric").disabled = false;
   }
 }
 
@@ -52,7 +70,7 @@ async function init() {
   try {
     const s = await invoke("get_lock_status");
     if (s.biometric_enabled) {
-      bio.textContent = "Use " + s.biometric_label;
+      bio.textContent = "Use " + (s.biometric_label || "biometrics");
       bio.hidden = false;
       tryBiometric(); // auto-prompt on load
     }

--- a/settings-ui/main.js
+++ b/settings-ui/main.js
@@ -18,10 +18,19 @@ async function save() {
   }
   const hk = document.getElementById("hotkey").value.trim();
   s.hotkey = hk || "CmdOrCtrl+Shift+W";
-  await invoke("set_settings", { settings: s });
   const note = document.getElementById("note");
-  note.textContent = "Saved ✓";
-  setTimeout(() => (note.textContent = ""), 1500);
+  try {
+    const warn = await invoke("set_settings", { settings: s });
+    if (warn) {
+      note.textContent = "Saved — shortcut not registered (may be in use): " + warn;
+      setTimeout(() => (note.textContent = ""), 6000);
+    } else {
+      note.textContent = "Saved ✓";
+      setTimeout(() => (note.textContent = ""), 1500);
+    }
+  } catch (e) {
+    note.textContent = String(e);
+  }
 }
 
 // --- Accounts ---

--- a/settings-ui/main.js
+++ b/settings-ui/main.js
@@ -133,6 +133,7 @@ window.addEventListener("DOMContentLoaded", () => {
   document.getElementById("new_account_name").addEventListener("keydown", (e) => {
     if (e.key === "Enter") addAccount();
   });
+  document.getElementById("record_hotkey").addEventListener("click", toggleRecording);
 });
 
 // --- App lock ---
@@ -219,4 +220,58 @@ function wireLock() {
     document.getElementById(id).addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
   }
   document.getElementById("idle_min").addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
+}
+
+// --- Shortcut recorder ---
+
+let recordingHotkey = false;
+let hotkeyPrev = "";
+const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"]);
+
+function setHotkeyHint(msg) {
+  const hint = document.getElementById("hotkey_hint");
+  if (!msg) { hint.hidden = true; hint.textContent = ""; }
+  else { hint.textContent = msg; hint.hidden = false; }
+}
+
+function stopRecording(restore) {
+  if (!recordingHotkey) return;
+  recordingHotkey = false;
+  window.removeEventListener("keydown", onRecordKeydown, true);
+  window.removeEventListener("blur", onRecordBlur, true);
+  const btn = document.getElementById("record_hotkey");
+  btn.textContent = "Record";
+  btn.classList.remove("recording");
+  if (restore) document.getElementById("hotkey").value = hotkeyPrev;
+}
+
+function onRecordBlur() { stopRecording(true); }
+
+function onRecordKeydown(e) {
+  e.preventDefault();
+  e.stopPropagation();
+  if (MODIFIER_KEYS.has(e.key)) return;            // ignore bare modifiers
+  if (e.key === "Escape") { setHotkeyHint(""); stopRecording(true); return; }
+  const mods = { ctrl: e.ctrlKey, alt: e.altKey, shift: e.shiftKey, meta: e.metaKey };
+  const accel = window.HotkeyFmt.comboToAccelerator(mods, e.code);
+  if (accel === null) { setHotkeyHint("Unsupported key — try another."); return; }
+  if (!window.HotkeyFmt.isValidCombo(mods, e.code)) {
+    setHotkeyHint("Add a modifier (Ctrl / Alt / Shift).");
+    return;
+  }
+  document.getElementById("hotkey").value = accel;
+  setHotkeyHint("");
+  stopRecording(false);
+}
+
+function toggleRecording() {
+  if (recordingHotkey) { setHotkeyHint(""); stopRecording(true); return; }
+  recordingHotkey = true;
+  hotkeyPrev = document.getElementById("hotkey").value;
+  const btn = document.getElementById("record_hotkey");
+  btn.textContent = "Press keys… (Esc to cancel)";
+  btn.classList.add("recording");
+  setHotkeyHint("");
+  window.addEventListener("keydown", onRecordKeydown, true);
+  window.addEventListener("blur", onRecordBlur, true);
 }

--- a/settings-ui/main.js
+++ b/settings-ui/main.js
@@ -126,9 +126,97 @@ async function addAccount() {
 window.addEventListener("DOMContentLoaded", () => {
   load();
   loadAccounts();
+  loadLock();
+  wireLock();
   document.getElementById("save").addEventListener("click", save);
   document.getElementById("add_account").addEventListener("click", addAccount);
   document.getElementById("new_account_name").addEventListener("keydown", (e) => {
     if (e.key === "Enter") addAccount();
   });
 });
+
+// --- App lock ---
+
+async function loadLock() {
+  let s;
+  try {
+    s = await invoke("get_lock_status");
+  } catch (e) {
+    return;
+  }
+  const disabled = document.getElementById("lock-disabled");
+  const enabled = document.getElementById("lock-enabled");
+  disabled.hidden = s.enabled;
+  enabled.hidden = !s.enabled;
+
+  if (s.enabled) {
+    const row = document.getElementById("biometric_row");
+    row.hidden = !s.biometric_available;
+    document.getElementById("biometric_label").textContent = "Use " + s.biometric_label;
+    document.getElementById("biometric_enabled").checked = s.biometric_enabled;
+    document.getElementById("lock_on_launch").checked = s.lock_on_launch;
+    document.getElementById("lock_on_hide").checked = s.lock_on_hide;
+    document.getElementById("idle_min").value = String(Math.round(s.idle_secs / 60));
+  }
+}
+
+async function saveLockOptions() {
+  const idleMin = parseInt(document.getElementById("idle_min").value, 10) || 0;
+  await invoke("set_app_lock_options", {
+    lockOnLaunch: document.getElementById("lock_on_launch").checked,
+    lockOnHide: document.getElementById("lock_on_hide").checked,
+    idleSecs: Math.max(0, idleMin) * 60,
+  });
+}
+
+function wireLock() {
+  document.getElementById("enable_lock").addEventListener("click", async () => {
+    const a = document.getElementById("lock_pw1").value;
+    const b = document.getElementById("lock_pw2").value;
+    try {
+      await invoke("set_app_lock_password", { new: a, confirm: b });
+      document.getElementById("lock_pw1").value = "";
+      document.getElementById("lock_pw2").value = "";
+      await loadLock();
+    } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("lock_now").addEventListener("click", async () => {
+    try { await invoke("lock_app"); } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("change_pw").addEventListener("click", async () => {
+    const current = prompt("Current password:");
+    if (current === null) return;
+    const next = prompt("New password (min 4):");
+    if (!next) return;
+    try {
+      await invoke("change_app_lock_password", { current, new: next, confirm: next });
+      alert("Password changed.");
+    } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("disable_lock").addEventListener("click", async () => {
+    const current = prompt("Enter your current password to disable the lock:");
+    if (current === null) return;
+    try {
+      await invoke("disable_app_lock", { current });
+      await loadLock();
+    } catch (e) { alert(String(e)); }
+  });
+
+  document.getElementById("biometric_enabled").addEventListener("change", async (e) => {
+    try {
+      await invoke("set_biometric_enabled", { enabled: e.target.checked });
+    } catch (err) {
+      alert(String(err));
+      e.target.checked = !e.target.checked; // revert on failure
+    }
+    await loadLock();
+  });
+
+  for (const id of ["lock_on_launch", "lock_on_hide"]) {
+    document.getElementById(id).addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
+  }
+  document.getElementById("idle_min").addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
+}

--- a/settings-ui/main.js
+++ b/settings-ui/main.js
@@ -245,7 +245,7 @@ function stopRecording(restore) {
   if (restore) document.getElementById("hotkey").value = hotkeyPrev;
 }
 
-function onRecordBlur() { stopRecording(true); }
+function onRecordBlur() { setHotkeyHint(""); stopRecording(true); }
 
 function onRecordKeydown(e) {
   e.preventDefault();

--- a/settings-ui/style.css
+++ b/settings-ui/style.css
@@ -58,3 +58,8 @@ h2 { font-size: 14px; margin: 0 0 10px; font-weight: 600; }
 .macos-note[hidden] { display: none; }
 .lock-note { font-size: 12px; color: #8696a0; margin-top: 10px; line-height: 1.4; }
 #lock-enabled .field input[type="number"] { width: 80px; }
+
+.hotkey-row { display: flex; gap: 8px; align-items: center; }
+.hotkey-row #hotkey { flex: 1; min-width: 0; }
+#record_hotkey.recording { background: #f0a500; color: #1a1a1a; }
+.hotkey-hint { font-size: 12px; color: #f0a500; margin: 4px 0 0; }

--- a/settings-ui/style.css
+++ b/settings-ui/style.css
@@ -56,3 +56,5 @@ h2 { font-size: 14px; margin: 0 0 10px; font-weight: 600; }
 .add-row button:disabled { opacity: 0.4; cursor: not-allowed; }
 .macos-note { color: #c0392b; font-size: 12px; margin: 8px 0 0; }
 .macos-note[hidden] { display: none; }
+.lock-note { font-size: 12px; color: #8696a0; margin-top: 10px; line-height: 1.4; }
+#lock-enabled .field input[type="number"] { width: 80px; }

--- a/settings-ui/style.css
+++ b/settings-ui/style.css
@@ -23,6 +23,8 @@ button {
   padding: 9px 18px; font-weight: 600; font-size: 14px; cursor: pointer;
 }
 button:hover { filter: brightness(1.05); }
+button.secondary { background: transparent; color: inherit; border: 1px solid #8886; }
+button.secondary:hover { filter: none; background: #8881; }
 .note { color: var(--green); font-weight: 600; }
 
 /* --- Accounts manager --- */

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2407,6 +2407,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-local-authentication"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48e0b8b339e0d9d2ed4416b7f93f9d4daadff7d4dd797f89867cde11aeac607"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2428,17 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3391,6 +3414,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -4669,7 +4698,10 @@ name = "whatrust"
 version = "0.2.0"
 dependencies = [
  "argon2",
+ "block2",
+ "objc2",
  "objc2-foundation",
+ "objc2-local-authentication",
  "serde",
  "serde_json",
  "tauri",
@@ -4684,6 +4716,8 @@ dependencies = [
  "webview2-com",
  "windows",
  "windows-core 0.61.2",
+ "zbus",
+ "zbus_polkit",
 ]
 
 [[package]]
@@ -5490,6 +5524,19 @@ dependencies = [
  "serde",
  "winnow 1.0.3",
  "zvariant",
+]
+
+[[package]]
+name = "zbus_polkit"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad23d5c4d198c7e2641b33e6e0d1f866f117408ba66fe80bbe52e289eeb77c52"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "serde_repr",
+ "static_assertions",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4607,7 +4607,6 @@ version = "0.2.0"
 dependencies = [
  "argon2",
  "objc2-foundation",
- "rand_core 0.6.4",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -717,6 +744,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2463,6 +2491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2761,7 +2800,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3324,6 +3372,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4551,7 +4605,9 @@ dependencies = [
 name = "whatrust"
 version = "0.2.0"
 dependencies = [
+ "argon2",
  "objc2-foundation",
+ "rand_core 0.6.4",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
  "webview2-com",
  "windows",
  "windows-core 0.61.2",
+ "windows-future",
  "zbus",
  "zbus_polkit",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,27 @@
 version = 3
 
 [[package]]
+name = "CoreFoundation-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
+dependencies = [
+ "libc",
+ "mach 0.1.2",
+]
+
+[[package]]
+name = "IOKit-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
+dependencies = [
+ "CoreFoundation-sys",
+ "libc",
+ "mach 0.1.2",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +663,16 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "cstr"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68523903c8ae5aacfa32a0d9ae60cadeb764e1da14ee0d26b1f3089f13a54636"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2051,6 +2082,24 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "time",
+]
+
+[[package]]
+name = "mach"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4299,6 +4348,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "user-idle"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433621584802937d26ab1b490236d802a9bc6d7176fe913cc12c2e51a790d5a2"
+dependencies = [
+ "CoreFoundation-sys",
+ "IOKit-sys",
+ "cstr",
+ "dbus",
+ "mach 0.3.2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,6 +4679,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
+ "user-idle",
  "webkit2gtk",
  "webview2-com",
  "windows",
@@ -4818,6 +4882,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4856,6 +4929,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4917,6 +5005,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4935,6 +5029,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4950,6 +5050,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4983,6 +5089,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4998,6 +5110,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5019,6 +5137,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5034,6 +5158,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "whatrust"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "argon2",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,18 +27,29 @@ argon2 = { version = "0.5.3", features = ["std"] }  # Argon2id password hashing 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Version-matched to wry 0.55's webkit2gtk so PlatformWebview::inner() types unify.
 webkit2gtk = "=2.0.2"
+zbus = "5"
+zbus_polkit = "5.0.0"
 
 [target.'cfg(windows)'.dependencies]
 # Version-matched to wry 0.55 for the WebView2 PermissionRequested mic/camera handler.
 webview2-com = "0.38"
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Com"] }
+windows = { version = "0.61", features = [
+  "Win32_Foundation",         # existing
+  "Win32_System_Com",         # existing (webview2 permission handler)
+  "Security_Credentials_UI",  # UserConsentVerifier + result/availability enums
+  "Win32_System_WinRT",       # IUserConsentVerifierInterop
+  "Foundation",               # IAsyncOperation
+] }
 windows-core = "0.61"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # macOS < 14 guard for data_store_identifier (per-account isolation). Already at
 # 0.3.2 in Cargo.lock via the dependency graph; the NSProcessInfo feature must be
-# explicit. Inert on Linux/Windows.
-objc2-foundation = { version = "0.3", features = ["NSProcessInfo"] }
+# explicit. Inert on Linux/Windows. NSString + NSError added for the Touch ID backend.
+objc2-foundation = { version = "0.3", features = ["NSProcessInfo", "NSString", "NSError"] }
+objc2-local-authentication = { version = "0.3.2", features = ["LAContext", "block2"] }
+objc2 = "0.6"
+block2 = "0.6"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,3 +46,4 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-window-state = "2"
+user-idle = { version = "0.6", default-features = false, features = ["dbus"] }  # system idle time for the idle auto-lock trigger (dbus: no libxss-dev needed)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,8 +22,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-argon2 = "0.5.3"  # Argon2id password hashing for the app lock (PHC strings)
-rand_core = { version = "0.6", features = ["getrandom"] }  # OsRng for Argon2 salt generation
+argon2 = { version = "0.5.3", features = ["std"] }  # Argon2id password hashing for the app lock (PHC strings)
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Version-matched to wry 0.55's webkit2gtk so PlatformWebview::inner() types unify.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,9 +38,12 @@ windows = { version = "0.61", features = [
   "Win32_System_Com",         # existing (webview2 permission handler)
   "Security_Credentials_UI",  # UserConsentVerifier + result/availability enums
   "Win32_System_WinRT",       # IUserConsentVerifierInterop
-  "Foundation",               # IAsyncOperation
+  "Foundation",               # async return-type plumbing
 ] }
 windows-core = "0.61"
+# In windows-rs 0.61 IAsyncOperation moved out of windows::Foundation into the
+# windows-future crate (0.2.1 is already in the tree via the windows stack).
+windows-future = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # macOS < 14 guard for data_store_identifier (per-account isolation). Already at

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+argon2 = "0.5.3"  # Argon2id password hashing for the app lock (PHC strings)
+rand_core = { version = "0.6", features = ["getrandom"] }  # OsRng for Argon2 salt generation
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Version-matched to wry 0.55's webkit2gtk so PlatformWebview::inner() types unify.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whatrust"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.82"
 

--- a/src-tauri/capabilities/lock.json
+++ b/src-tauri/capabilities/lock.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "lock-local",
+  "description": "IPC for the app-lock screen. core:default for invoke; no remote, no account/notification permissions. Per-command authorization is enforced in Rust (is_lock_window).",
+  "windows": ["lock"],
+  "permissions": ["core:default"]
+}

--- a/src-tauri/resources/com.karem.whatrust.policy
+++ b/src-tauri/resources/com.karem.whatrust.policy
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>whatRust</vendor>
+  <action id="com.karem.whatrust.unlock">
+    <description>Unlock whatRust</description>
+    <message>Authenticate to unlock whatRust</message>
+    <defaults>
+      <allow_any>auth_self</allow_any>
+      <allow_inactive>auth_self</allow_inactive>
+      <allow_active>auth_self</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/src-tauri/src/applock.rs
+++ b/src-tauri/src/applock.rs
@@ -1,0 +1,149 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+/// Persisted app-lock configuration. Stored in its own `app-lock.json` (NOT in
+/// settings.json) so the password hash never rides along with the general settings
+/// blob and is never serialized to the frontend.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AppLockConfig {
+    pub enabled: bool,
+    /// Argon2id PHC string (salt embedded). `None` when the lock is disabled.
+    pub password_phc: Option<String>,
+    pub biometric_enabled: bool,
+    pub lock_on_launch: bool,
+    pub lock_on_hide: bool,
+    /// Idle auto-lock threshold in seconds. 0 == off.
+    pub idle_secs: u32,
+}
+
+impl Default for AppLockConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            password_phc: None,
+            biometric_enabled: false,
+            lock_on_launch: true,
+            lock_on_hide: false,
+            idle_secs: 0,
+        }
+    }
+}
+
+impl AppLockConfig {
+    /// The lock is only truly active when it is enabled AND a password exists. A
+    /// bare `enabled` with no hash can never lock the user out.
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.password_phc.is_some()
+    }
+}
+
+fn config_path(app: &AppHandle) -> tauri::Result<PathBuf> {
+    let dir = app.path().app_config_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir.join("app-lock.json"))
+}
+
+pub fn load(app: &AppHandle) -> AppLockConfig {
+    config_path(app)
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+pub fn save(app: &AppHandle, c: &AppLockConfig) -> tauri::Result<()> {
+    let path = config_path(app)?;
+    let json = serde_json::to_string_pretty(c).expect("serialize app-lock config");
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Hash a passcode into an Argon2id PHC string. `Argon2::default()` is Argon2id,
+/// version 0x13, with OWASP-baseline parameters. The random salt is embedded in the
+/// returned PHC string, so nothing else needs storing.
+pub fn hash_password(password: &str) -> Result<String, String> {
+    use argon2::password_hash::{PasswordHasher, SaltString};
+    use argon2::Argon2;
+    use rand_core::OsRng;
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| e.to_string())
+}
+
+/// Verify a passcode against a stored PHC string. Returns false on any parse/verify
+/// error (never panics, never leaks which step failed).
+pub fn verify_password(password: &str, phc: &str) -> bool {
+    use argon2::password_hash::{PasswordHash, PasswordVerifier};
+    use argon2::Argon2;
+    match PasswordHash::new(phc) {
+        Ok(parsed) => Argon2::default()
+            .verify_password(password.as_bytes(), &parsed)
+            .is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_sane() {
+        let c = AppLockConfig::default();
+        assert!(!c.enabled);
+        assert!(c.password_phc.is_none());
+        assert!(!c.biometric_enabled);
+        assert!(c.lock_on_launch);
+        assert!(!c.lock_on_hide); // user decision: hide-to-tray lock ships OFF
+        assert_eq!(c.idle_secs, 0);
+    }
+
+    #[test]
+    fn is_active_requires_enabled_and_hash() {
+        let mut c = AppLockConfig::default();
+        assert!(!c.is_active());
+        c.enabled = true;
+        assert!(!c.is_active(), "enabled without a hash must not be active");
+        c.password_phc = Some("x".into());
+        assert!(c.is_active());
+    }
+
+    #[test]
+    fn partial_json_fills_defaults() {
+        let c: AppLockConfig = serde_json::from_str(r#"{"enabled": true}"#).unwrap();
+        assert!(c.enabled);
+        assert!(c.lock_on_launch);
+        assert!(!c.lock_on_hide);
+        assert_eq!(c.idle_secs, 0);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let c = AppLockConfig { enabled: true, idle_secs: 300, ..Default::default() };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: AppLockConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn hash_then_verify_roundtrips() {
+        let phc = hash_password("correct horse").unwrap();
+        assert!(phc.starts_with("$argon2id$"), "must be Argon2id: {phc}");
+        assert!(verify_password("correct horse", &phc));
+    }
+
+    #[test]
+    fn wrong_password_fails() {
+        let phc = hash_password("secret").unwrap();
+        assert!(!verify_password("nope", &phc));
+    }
+
+    #[test]
+    fn verify_rejects_garbage_phc() {
+        assert!(!verify_password("anything", "not-a-phc-string"));
+    }
+}

--- a/src-tauri/src/applock.rs
+++ b/src-tauri/src/applock.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 
 /// Persisted app-lock configuration. Stored in its own `app-lock.json` (NOT in
@@ -87,28 +87,40 @@ pub fn verify_password(password: &str, phc: &str) -> bool {
     }
 }
 
-/// Factory-reset everything the lock could gate: every account profile dir, the
-/// default webview store, accounts.json, and app-lock.json. Used by the forgot-
-/// password reset. Best-effort: ignores individual delete errors.
+/// Paths a factory reset removes, given whatRust's two app dirs. Pure so it can be
+/// unit-tested. `app_data_dir` is whatRust-exclusive (`<base>/com.karem.whatrust`) and
+/// holds BOTH the default account's webview store (directly under it, on Linux/Windows)
+/// and the per-account `profiles/` dirs — removing it logs every account out.
+fn reset_targets(config_dir: &Path, data_dir: &Path) -> Vec<PathBuf> {
+    vec![
+        config_dir.join("accounts.json"),
+        config_dir.join("app-lock.json"),
+        data_dir.to_path_buf(),
+    ]
+}
+
+/// Factory reset for the forgot-password flow: log out ALL accounts and clear the lock.
 pub fn reset_all(app: &AppHandle) {
-    // Per-account isolated profiles + the default shared store.
+    // Belt-and-suspenders: explicitly drop each per-account profile first.
     let f = crate::accounts::load(app);
     for a in &f.accounts {
         crate::accounts::delete_profile(app, &a.id);
     }
-    if let Ok(dir) = app.path().app_config_dir() {
-        let _ = std::fs::remove_file(dir.join("accounts.json"));
-        let _ = std::fs::remove_file(dir.join("app-lock.json"));
-    }
-    // The default account's webview data lives under the app data dir.
-    if let Ok(data) = app.path().app_data_dir() {
-        // Remove only known webview store dirs; do not nuke the whole data dir blindly.
-        // NOTE: ["EBWebView", "default"] is a best-effort guess for the default-account
-        // webview store path and must be confirmed on Linux in the Task 10 smoke test.
-        for sub in ["EBWebView", "default"] {
-            let _ = std::fs::remove_dir_all(data.join(sub));
+    // Then remove the config files + the whole data root (default store + profiles).
+    let config_dir = app.path().app_config_dir().ok();
+    let data_dir = app.path().app_data_dir().ok();
+    if let (Some(c), Some(d)) = (config_dir, data_dir) {
+        for p in reset_targets(&c, &d) {
+            if p.is_dir() {
+                let _ = std::fs::remove_dir_all(&p);
+            } else {
+                let _ = std::fs::remove_file(&p);
+            }
         }
     }
+    // NOTE (macOS, hardware-pending): the default account uses the system WKWebsiteDataStore
+    // and additional accounts use data_store_identifier — both system-managed, NOT plain files
+    // under app_data_dir, so file deletion alone may not fully log out on macOS. Verify on a Mac.
 }
 
 #[cfg(test)]
@@ -175,5 +187,17 @@ mod tests {
     #[test]
     fn verify_rejects_garbage_phc() {
         assert!(!verify_password("anything", "not-a-phc-string"));
+    }
+
+    #[test]
+    fn reset_targets_cover_config_files_and_the_data_root() {
+        use std::path::Path;
+        let cfg = Path::new("/x/config");
+        let data = Path::new("/x/data");
+        let t = super::reset_targets(cfg, data);
+        assert!(t.contains(&cfg.join("accounts.json")));
+        assert!(t.contains(&cfg.join("app-lock.json")));
+        // The data root must be a target — this is what logs the DEFAULT account out.
+        assert!(t.contains(&data.to_path_buf()));
     }
 }

--- a/src-tauri/src/applock.rs
+++ b/src-tauri/src/applock.rs
@@ -87,6 +87,30 @@ pub fn verify_password(password: &str, phc: &str) -> bool {
     }
 }
 
+/// Factory-reset everything the lock could gate: every account profile dir, the
+/// default webview store, accounts.json, and app-lock.json. Used by the forgot-
+/// password reset. Best-effort: ignores individual delete errors.
+pub fn reset_all(app: &AppHandle) {
+    // Per-account isolated profiles + the default shared store.
+    let f = crate::accounts::load(app);
+    for a in &f.accounts {
+        crate::accounts::delete_profile(app, &a.id);
+    }
+    if let Ok(dir) = app.path().app_config_dir() {
+        let _ = std::fs::remove_file(dir.join("accounts.json"));
+        let _ = std::fs::remove_file(dir.join("app-lock.json"));
+    }
+    // The default account's webview data lives under the app data dir.
+    if let Ok(data) = app.path().app_data_dir() {
+        // Remove only known webview store dirs; do not nuke the whole data dir blindly.
+        // NOTE: ["EBWebView", "default"] is a best-effort guess for the default-account
+        // webview store path and must be confirmed on Linux in the Task 10 smoke test.
+        for sub in ["EBWebView", "default"] {
+            let _ = std::fs::remove_dir_all(data.join(sub));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/applock.rs
+++ b/src-tauri/src/applock.rs
@@ -64,9 +64,9 @@ pub fn save(app: &AppHandle, c: &AppLockConfig) -> tauri::Result<()> {
 /// version 0x13, with OWASP-baseline parameters. The random salt is embedded in the
 /// returned PHC string, so nothing else needs storing.
 pub fn hash_password(password: &str) -> Result<String, String> {
+    use argon2::password_hash::rand_core::OsRng;
     use argon2::password_hash::{PasswordHasher, SaltString};
     use argon2::Argon2;
-    use rand_core::OsRng;
     let salt = SaltString::generate(&mut OsRng);
     Argon2::default()
         .hash_password(password.as_bytes(), &salt)
@@ -119,6 +119,12 @@ mod tests {
         assert!(c.lock_on_launch);
         assert!(!c.lock_on_hide);
         assert_eq!(c.idle_secs, 0);
+    }
+
+    #[test]
+    fn empty_json_is_all_defaults() {
+        let c: AppLockConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(c, AppLockConfig::default());
     }
 
     #[test]

--- a/src-tauri/src/biometric/linux.rs
+++ b/src-tauri/src/biometric/linux.rs
@@ -1,0 +1,39 @@
+use super::Availability;
+use std::collections::HashMap;
+use zbus::blocking::Connection;
+use zbus_polkit::policykit1::{AuthorityProxyBlocking, CheckAuthorizationFlags, Subject};
+
+const ACTION_ID: &str = "com.karem.whatrust.unlock";
+
+pub fn availability() -> Availability {
+    // Connection::system() and AuthorityProxyBlocking::new both return zbus::Result,
+    // so and_then unifies cleanly here (no Box needed).
+    match Connection::system().and_then(|c| AuthorityProxyBlocking::new(&c)) {
+        Ok(_) => Availability::Available,
+        Err(_) => Availability::NotConfigured,
+    }
+}
+
+pub fn authenticate(_app: &tauri::AppHandle, _reason: &str) -> Result<bool, String> {
+    check_polkit_unlock().map_err(|e| e.to_string())
+}
+
+/// Box<dyn Error> so both zbus::Error and zbus_polkit::Error convert via `?`.
+fn check_polkit_unlock() -> Result<bool, Box<dyn std::error::Error>> {
+    let conn = Connection::system()?;
+    // BLOCKING proxy — async AuthorityProxy would require &zbus::Connection + .await.
+    let authority = AuthorityProxyBlocking::new(&conn)?;
+    // Subject = this process. polkit resolves the action, popping the desktop's polkit
+    // agent dialog (fingerprint where pam_fprintd is configured).
+    // new_for_owner(pid: u32, start_time: Option<u64>, uid: Option<u32>)
+    let subject = Subject::new_for_owner(std::process::id(), None, None)?;
+    let details: HashMap<&str, &str> = HashMap::new();
+    let result = authority.check_authorization(
+        &subject,
+        ACTION_ID,
+        &details,
+        CheckAuthorizationFlags::AllowUserInteraction.into(), // -> BitFlags<CheckAuthorizationFlags>
+        "", // cancellation_id
+    )?;
+    Ok(result.is_authorized)
+}

--- a/src-tauri/src/biometric/macos.rs
+++ b/src-tauri/src/biometric/macos.rs
@@ -1,0 +1,41 @@
+use super::Availability;
+use block2::RcBlock;
+use objc2_foundation::NSString;
+use objc2_local_authentication::{LAContext, LAPolicy};
+use std::sync::mpsc;
+
+pub fn availability() -> Availability {
+    let ctx = unsafe { LAContext::new() };
+    let can = unsafe {
+        ctx.canEvaluatePolicy_error(LAPolicy::DeviceOwnerAuthenticationWithBiometrics)
+    };
+    match can {
+        Ok(()) => Availability::Available,
+        Err(_) => Availability::NotConfigured,
+    }
+}
+
+pub fn authenticate(_app: &tauri::AppHandle, reason: &str) -> Result<bool, String> {
+    // Fresh context per call (LAContext caches a prior success).
+    let ctx = unsafe { LAContext::new() };
+    let reason = if reason.is_empty() { "Unlock whatRust" } else { reason };
+    let ns_reason = NSString::from_str(reason);
+
+    let (tx, rx) = mpsc::channel::<bool>();
+    let block = RcBlock::new(move |success: objc2::runtime::Bool, _err: *mut objc2_foundation::NSError| {
+        let _ = tx.send(success.as_bool());
+    });
+
+    unsafe {
+        // DeviceOwnerAuthentication = Touch ID OR the login password as fallback.
+        ctx.evaluatePolicy_localizedReason_reply(
+            LAPolicy::DeviceOwnerAuthentication,
+            &ns_reason,
+            &block,
+        );
+    }
+
+    // The reply block fires on a background thread; block until it does (with a cap).
+    rx.recv_timeout(std::time::Duration::from_secs(60))
+        .map_err(|_| "biometric prompt timed out".to_string())
+}

--- a/src-tauri/src/biometric/mod.rs
+++ b/src-tauri/src/biometric/mod.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Availability {
+    Available,
+    NotConfigured,
+    Unsupported,
+}
+
+pub fn availability() -> Availability {
+    Availability::Unsupported
+}
+
+pub fn authenticate(_app: &tauri::AppHandle, _reason: &str) -> Result<bool, String> {
+    Err("biometric authentication is not available on this platform".into())
+}
+
+pub fn label() -> &'static str {
+    "biometric"
+}

--- a/src-tauri/src/biometric/mod.rs
+++ b/src-tauri/src/biometric/mod.rs
@@ -1,18 +1,50 @@
+//! Per-platform desktop biometric / local-auth. The default ("password-only") account
+//! never touches this; it's an optional unlock shortcut. Every backend returns a plain
+//! yes/no — no key material — so it can gate the UI but cannot decrypt anything.
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Availability {
+    /// Usable now (Hello configured / Touch ID enrolled / polkit reachable).
     Available,
+    /// The mechanism exists but isn't set up (no enrolled print, no agent, etc.).
     NotConfigured,
+    /// Not supported on this OS / version.
     Unsupported,
 }
 
+#[cfg(target_os = "linux")]
+#[path = "linux.rs"]
+mod platform;
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod platform;
+#[cfg(target_os = "macos")]
+#[path = "macos.rs"]
+mod platform;
+
+#[cfg(not(any(target_os = "linux", windows, target_os = "macos")))]
+compile_error!("biometric auth is not implemented for this platform");
+
 pub fn availability() -> Availability {
-    Availability::Unsupported
+    platform::availability()
 }
 
-pub fn authenticate(_app: &tauri::AppHandle, _reason: &str) -> Result<bool, String> {
-    Err("biometric authentication is not available on this platform".into())
+/// Blocking. `reason` must be non-empty (macOS aborts on an empty reason).
+pub fn authenticate(app: &tauri::AppHandle, reason: &str) -> Result<bool, String> {
+    platform::authenticate(app, reason)
 }
 
 pub fn label() -> &'static str {
-    "biometric"
+    #[cfg(target_os = "windows")]
+    {
+        "Windows Hello"
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "Touch ID"
+    }
+    #[cfg(target_os = "linux")]
+    {
+        "system authentication"
+    }
 }

--- a/src-tauri/src/biometric/mod.rs
+++ b/src-tauri/src/biometric/mod.rs
@@ -8,7 +8,9 @@ pub enum Availability {
     Available,
     /// The mechanism exists but isn't set up (no enrolled print, no agent, etc.).
     NotConfigured,
-    /// Not supported on this OS / version.
+    /// Not supported on this OS / version. Only constructed by the Windows/macOS
+    /// backends; appears unused on Linux where polkit yields Available/NotConfigured.
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
     Unsupported,
 }
 

--- a/src-tauri/src/biometric/windows.rs
+++ b/src-tauri/src/biometric/windows.rs
@@ -1,7 +1,9 @@
 use super::Availability;
 use tauri::Manager;
 use windows::core::{factory, HSTRING};
-use windows::Foundation::IAsyncOperation;
+// In windows-rs 0.61 the async operation types live in the windows-future crate,
+// NOT windows::Foundation. `IAsyncOperation::get()` (blocking) is from there too.
+use windows_future::IAsyncOperation;
 use windows::Security::Credentials::UI::{
     UserConsentVerificationResult, UserConsentVerifier, UserConsentVerifierAvailability,
 };

--- a/src-tauri/src/biometric/windows.rs
+++ b/src-tauri/src/biometric/windows.rs
@@ -1,0 +1,39 @@
+use super::Availability;
+use tauri::Manager;
+use windows::core::{factory, HSTRING};
+use windows::Foundation::IAsyncOperation;
+use windows::Security::Credentials::UI::{
+    UserConsentVerificationResult, UserConsentVerifier, UserConsentVerifierAvailability,
+};
+// IUserConsentVerifierInterop lives in Win32::System::WinRT, NOT Security::Credentials::UI:
+use windows::Win32::System::WinRT::IUserConsentVerifierInterop;
+
+pub fn availability() -> Availability {
+    match UserConsentVerifier::CheckAvailabilityAsync().and_then(|op| op.get()) {
+        Ok(UserConsentVerifierAvailability::Available) => Availability::Available,
+        Ok(_) => Availability::NotConfigured,
+        Err(_) => Availability::Unsupported,
+    }
+}
+
+pub fn authenticate(app: &tauri::AppHandle, reason: &str) -> Result<bool, String> {
+    // MUST query availability first, or RequestVerification hangs.
+    let _ = UserConsentVerifier::CheckAvailabilityAsync().and_then(|op| op.get());
+
+    let win = app
+        .get_webview_window("lock")
+        .or_else(|| app.webview_windows().into_values().next())
+        .ok_or("no window to host the Hello prompt")?;
+    let hwnd = win.hwnd().map_err(|e| e.to_string())?;
+
+    let interop: IUserConsentVerifierInterop =
+        factory::<UserConsentVerifier, IUserConsentVerifierInterop>().map_err(|e| e.to_string())?;
+    let msg = HSTRING::from(reason);
+    let op: IAsyncOperation<UserConsentVerificationResult> =
+        unsafe { interop.RequestVerificationForWindowAsync(hwnd, &msg) }.map_err(|e| e.to_string())?;
+    match op.get() {
+        Ok(UserConsentVerificationResult::Verified) => Ok(true),
+        Ok(_) => Ok(false),
+        Err(e) => Err(e.to_string()),
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,6 @@
 use crate::accounts::{self, ActiveAccount, UnreadMap};
+use crate::applock::{self, AppLockConfig};
+use crate::lock;
 use crate::settings::Settings;
 use serde::Serialize;
 use tauri::Manager;
@@ -68,6 +70,7 @@ pub fn get_settings(window: tauri::Window, app: tauri::AppHandle) -> Result<Sett
     if is_remote(&window) {
         return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
     Ok(crate::settings::load(&app))
 }
 
@@ -80,17 +83,20 @@ pub fn set_settings(
     if is_remote(&window) {
         return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
     crate::settings::save(&app, &settings).map_err(|e| e.to_string())?;
     crate::settings::apply(&app, &settings);
     Ok(())
 }
 
 #[tauri::command]
-pub fn open_settings(window: tauri::Window, app: tauri::AppHandle) {
+pub fn open_settings(window: tauri::Window, app: tauri::AppHandle) -> Result<(), String> {
     if is_remote(&window) {
-        return;
+        return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
     crate::window::open_settings_window(&app);
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -135,6 +141,7 @@ pub fn list_accounts(
     if is_remote(&window) {
         return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
     Ok(account_views(&app))
 }
 
@@ -147,6 +154,7 @@ pub fn add_account(
     if is_remote(&window) {
         return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
     // macOS < 14 cannot isolate additional accounts (no data_store_identifier).
     crate::window::ensure_isolation_supported()?;
 
@@ -180,6 +188,7 @@ pub fn remove_account(
     if is_remote(&window) {
         return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
 
     let mut f = accounts::load(&app);
     let removed = accounts::remove(&mut f, &id)?;
@@ -218,6 +227,7 @@ pub fn rename_account(
     if is_remote(&window) {
         return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
     let name = name.trim();
     if name.is_empty() {
         return Err("account name cannot be empty".into());
@@ -239,6 +249,7 @@ pub fn open_account(window: tauri::Window, app: tauri::AppHandle, id: String) ->
     if is_remote(&window) {
         return Err("forbidden".into());
     }
+    lock::require_unlocked(&app)?;
     let f = accounts::load(&app);
     let Some(acct) = f.accounts.iter().find(|a| a.id == id) else {
         return Err(format!("unknown account: {id}"));
@@ -256,6 +267,231 @@ pub fn open_account(window: tauri::Window, app: tauri::AppHandle, id: String) ->
         *active.lock().unwrap() = accounts::window_label(&acct.id);
     }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// App-lock commands.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LockStatus {
+    pub enabled: bool,
+    pub biometric_available: bool,
+    pub biometric_enabled: bool,
+    pub biometric_label: String,
+    pub lock_on_launch: bool,
+    pub lock_on_hide: bool,
+    pub idle_secs: u32,
+}
+
+/// Read-only status for BOTH the settings window and the lock screen. Never returns
+/// the password hash. Allowed from any non-remote window, even while locked.
+#[tauri::command]
+pub fn get_lock_status(window: tauri::Window, app: tauri::AppHandle) -> Result<LockStatus, String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    let c = applock::load(&app);
+    let available = matches!(crate::biometric::availability(), crate::biometric::Availability::Available);
+    Ok(LockStatus {
+        enabled: c.is_active(),
+        biometric_available: available,
+        biometric_enabled: c.biometric_enabled && available,
+        biometric_label: crate::biometric::label().to_string(),
+        lock_on_launch: c.lock_on_launch,
+        lock_on_hide: c.lock_on_hide,
+        idle_secs: c.idle_secs,
+    })
+}
+
+/// Enable the lock by setting the first password. Errors if already enabled (use
+/// `change_app_lock_password`). Runs only from an unlocked, local window.
+#[tauri::command]
+pub fn set_app_lock_password(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    new: String,
+    confirm: String,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    if c.is_active() {
+        return Err("app lock is already enabled".into());
+    }
+    if new != confirm {
+        return Err("passwords do not match".into());
+    }
+    if new.chars().count() < 4 {
+        return Err("password must be at least 4 characters".into());
+    }
+    c.password_phc = Some(applock::hash_password(&new)?);
+    c.enabled = true;
+    applock::save(&app, &c).map_err(|e| e.to_string())?;
+    crate::tray::rebuild_menu(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn change_app_lock_password(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    current: String,
+    new: String,
+    confirm: String,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    let phc = c.password_phc.clone().ok_or("app lock is not enabled")?;
+    if !applock::verify_password(&current, &phc) {
+        return Err("current password is incorrect".into());
+    }
+    if new != confirm {
+        return Err("passwords do not match".into());
+    }
+    if new.chars().count() < 4 {
+        return Err("password must be at least 4 characters".into());
+    }
+    c.password_phc = Some(applock::hash_password(&new)?);
+    applock::save(&app, &c).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn disable_app_lock(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    current: String,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    let phc = c.password_phc.clone().ok_or("app lock is not enabled")?;
+    if !applock::verify_password(&current, &phc) {
+        return Err("current password is incorrect".into());
+    }
+    c = AppLockConfig::default(); // fully reset: disabled, no hash, no biometric, default triggers
+    applock::save(&app, &c).map_err(|e| e.to_string())?;
+    crate::tray::rebuild_menu(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn set_app_lock_options(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    lock_on_launch: bool,
+    lock_on_hide: bool,
+    idle_secs: u32,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    c.lock_on_launch = lock_on_launch;
+    c.lock_on_hide = lock_on_hide;
+    c.idle_secs = idle_secs;
+    applock::save(&app, &c).map_err(|e| e.to_string())
+}
+
+/// Enable/disable biometric. Enabling requires the lock to be set, the platform to
+/// report Available, and one successful test authentication.
+#[tauri::command]
+pub fn set_biometric_enabled(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    enabled: bool,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let mut c = applock::load(&app);
+    if enabled {
+        if !c.is_active() {
+            return Err("set an app-lock password first".into());
+        }
+        if !matches!(crate::biometric::availability(), crate::biometric::Availability::Available) {
+            return Err("biometric authentication is not available on this device".into());
+        }
+        if !crate::biometric::authenticate(&app, "Enable biometric unlock for whatRust")? {
+            return Err("biometric test did not succeed".into());
+        }
+    }
+    c.biometric_enabled = enabled;
+    applock::save(&app, &c).map_err(|e| e.to_string())
+}
+
+/// Manual "Lock now" from the settings window.
+#[tauri::command]
+pub fn lock_app(window: tauri::Window, app: tauri::AppHandle) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    if !applock::load(&app).is_active() {
+        return Err("app lock is not enabled".into());
+    }
+    lock::lock_now(&app);
+    Ok(())
+}
+
+/// Unlock with the password. Lock-window only; works while locked (no require_unlocked).
+#[tauri::command]
+pub fn unlock_password(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    password: String,
+) -> Result<bool, String> {
+    if !lock::is_lock_window(&window) {
+        return Err("forbidden".into());
+    }
+    let c = applock::load(&app);
+    let Some(phc) = c.password_phc else {
+        // No lock configured — treat as already unlocked.
+        lock::unlock(&app);
+        return Ok(true);
+    };
+    if applock::verify_password(&password, &phc) {
+        lock::unlock(&app);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Unlock with biometric. Lock-window only; works while locked.
+#[tauri::command]
+pub fn unlock_biometric(window: tauri::Window, app: tauri::AppHandle) -> Result<bool, String> {
+    if !lock::is_lock_window(&window) {
+        return Err("forbidden".into());
+    }
+    if !applock::load(&app).biometric_enabled {
+        return Err("biometric unlock is not enabled".into());
+    }
+    if crate::biometric::authenticate(&app, "Unlock whatRust")? {
+        lock::unlock(&app);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Forgot-password reset: wipe ALL account sessions + the app-lock config, then
+/// relaunch fresh (logged out, lock disabled). Lock-window only.
+#[tauri::command]
+pub fn reset_app_lock(window: tauri::Window, app: tauri::AppHandle) -> Result<(), String> {
+    if !lock::is_lock_window(&window) {
+        return Err("forbidden".into());
+    }
+    crate::applock::reset_all(&app);
+    app.restart();
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,6 +22,12 @@ fn is_remote_label(label: &str) -> bool {
 
 #[tauri::command]
 pub fn notify(window: tauri::Window, app: tauri::AppHandle, title: String, body: String) {
+    // While locked, suppress notifications entirely so message previews don't leak
+    // to the OS notification center / lock screen. The tray unread badge still updates
+    // via set_unread (a count only, no content).
+    if !crate::lock::is_unlocked(&app) {
+        return;
+    }
     if !crate::settings::load(&app).notifications {
         return;
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -85,14 +85,13 @@ pub fn set_settings(
     window: tauri::Window,
     app: tauri::AppHandle,
     settings: Settings,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     if is_remote(&window) {
         return Err("forbidden".into());
     }
     lock::require_unlocked(&app)?;
     crate::settings::save(&app, &settings).map_err(|e| e.to_string())?;
-    crate::settings::apply(&app, &settings);
-    Ok(())
+    Ok(crate::settings::apply(&app, &settings))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod accounts;
 mod applock;
+mod lock;
 mod window;
 mod unread;
 mod settings;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod accounts;
+mod applock;
 mod window;
 mod unread;
 mod settings;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod accounts;
 mod applock;
+mod biometric;
 mod lock;
 mod window;
 mod unread;
@@ -86,6 +87,16 @@ pub fn run() {
             commands::remove_account,
             commands::rename_account,
             commands::open_account,
+            commands::get_lock_status,
+            commands::set_app_lock_password,
+            commands::change_app_lock_password,
+            commands::disable_app_lock,
+            commands::set_app_lock_options,
+            commands::set_biometric_enabled,
+            commands::lock_app,
+            commands::unlock_password,
+            commands::unlock_biometric,
+            commands::reset_app_lock,
         ])
         .setup(|app| {
             let handle = app.handle();
@@ -109,14 +120,24 @@ pub fn run() {
                 let _ = accounts::save(handle, &f);
             }
 
+            // App lock: decide the initial state and whether to start hidden.
+            let lock_cfg = applock::load(handle);
+            let lock_on_launch = lock_cfg.is_active() && lock_cfg.lock_on_launch;
+            handle.manage(lock::LockState::new(!lock_on_launch));
+            let open_hidden = start_hidden || lock_on_launch;
+
             // Open every account window so each one receives messages/notifications.
             for a in &f.accounts {
-                window::open_account_window(handle, a, start_hidden)?;
+                window::open_account_window(handle, a, open_hidden)?;
             }
 
             tray::setup(handle)?;
             tray::rebuild_menu(handle);
             settings::apply(handle, &s);
+
+            if lock_on_launch && !start_hidden {
+                lock::show_lock_window(handle);
+            }
             Ok(())
         })
         .build(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,6 +138,31 @@ pub fn run() {
             if lock_on_launch && !start_hidden {
                 lock::show_lock_window(handle);
             }
+
+            // Idle auto-lock watcher. Always running; no-op unless the lock is active
+            // with idle_secs > 0 and the app is currently unlocked.
+            #[cfg(desktop)]
+            {
+                let idle_handle = handle.clone();
+                std::thread::spawn(move || loop {
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    let c = applock::load(&idle_handle);
+                    if !c.is_active() || c.idle_secs == 0 {
+                        continue;
+                    }
+                    if !lock::is_unlocked(&idle_handle) {
+                        continue;
+                    }
+                    let idle_ok = user_idle::UserIdle::get_time()
+                        .map(|t| t.as_seconds() >= c.idle_secs as u64)
+                        .unwrap_or(false);
+                    if idle_ok {
+                        let h = idle_handle.clone();
+                        let _ = idle_handle.run_on_main_thread(move || lock::lock_now(&h));
+                    }
+                });
+            }
+
             Ok(())
         })
         .build(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,7 +133,7 @@ pub fn run() {
 
             tray::setup(handle)?;
             tray::rebuild_menu(handle);
-            settings::apply(handle, &s);
+            let _ = settings::apply(handle, &s);
 
             if lock_on_launch && !start_hidden {
                 lock::show_lock_window(handle);

--- a/src-tauri/src/lock.rs
+++ b/src-tauri/src/lock.rs
@@ -56,6 +56,12 @@ pub fn lock_now(app: &AppHandle) {
         Some(s) => s,
         None => return, // not yet set up — bail
     };
+    // Idempotent: if already locked, just ensure the lock screen is up — do NOT
+    // re-hide windows or clobber the recorded `hidden` list (which unlock restores).
+    if !*state.unlocked.lock().unwrap() {
+        show_lock_window(app);
+        return;
+    }
     *state.unlocked.lock().unwrap() = false;
     let mut hidden = Vec::new();
     for (label, w) in app.webview_windows() {

--- a/src-tauri/src/lock.rs
+++ b/src-tauri/src/lock.rs
@@ -1,0 +1,147 @@
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// Runtime lock state. `unlocked == false` means the app is locked.
+pub struct LockState {
+    pub unlocked: Mutex<bool>,
+    /// Labels of windows hidden by `lock_now`, to re-show on `unlock`.
+    pub hidden: Mutex<Vec<String>>,
+}
+
+impl LockState {
+    pub fn new(unlocked: bool) -> Self {
+        Self {
+            unlocked: Mutex::new(unlocked),
+            hidden: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+/// Whether a window label should be hidden behind the lock screen. Pure, unit-tested.
+/// The lock window itself is never hidden; everything user-facing (`wa-*` + settings) is.
+pub fn should_hide(label: &str) -> bool {
+    label != "lock" && (label.starts_with("wa-") || label == "settings")
+}
+
+/// Pure predicate behind the lock-window IPC guard.
+pub fn is_lock_label(label: &str) -> bool {
+    label == "lock"
+}
+
+pub fn is_lock_window(window: &tauri::Window) -> bool {
+    is_lock_label(window.label())
+}
+
+/// Read the current unlocked flag. Defaults to `true` (unlocked) when the state is
+/// not yet managed, so nothing is accidentally gated before setup runs.
+pub fn is_unlocked(app: &AppHandle) -> bool {
+    app.try_state::<LockState>()
+        .map(|s| *s.unlocked.lock().unwrap())
+        .unwrap_or(true)
+}
+
+/// IPC guard for sensitive commands.
+pub fn require_unlocked(app: &AppHandle) -> Result<(), String> {
+    if is_unlocked(app) {
+        Ok(())
+    } else {
+        Err("locked".into())
+    }
+}
+
+/// Lock the app: mark locked, hide every user-facing window (recording which were
+/// visible), and show the lock screen.
+pub fn lock_now(app: &AppHandle) {
+    if let Some(state) = app.try_state::<LockState>() {
+        *state.unlocked.lock().unwrap() = false;
+    }
+    let mut hidden = Vec::new();
+    for (label, w) in app.webview_windows() {
+        if should_hide(&label) && w.is_visible().unwrap_or(false) {
+            let _ = w.hide();
+            hidden.push(label);
+        }
+    }
+    if let Some(state) = app.try_state::<LockState>() {
+        *state.hidden.lock().unwrap() = hidden;
+    }
+    show_lock_window(app);
+}
+
+/// Unlock the app: mark unlocked, destroy the lock window, and restore the windows
+/// that were visible when we locked (or fall back to the active account).
+pub fn unlock(app: &AppHandle) {
+    if let Some(state) = app.try_state::<LockState>() {
+        *state.unlocked.lock().unwrap() = true;
+    }
+    if let Some(w) = app.get_webview_window("lock") {
+        let _ = w.destroy();
+    }
+    let hidden = app
+        .try_state::<LockState>()
+        .map(|s| std::mem::take(&mut *s.hidden.lock().unwrap()))
+        .unwrap_or_default();
+    if hidden.is_empty() {
+        crate::window::show_active(app);
+    } else {
+        for label in hidden {
+            crate::window::show_account(app, &label);
+        }
+    }
+}
+
+/// Create-or-show the dedicated lock window. `content_protected` blocks screen
+/// capture of the lock screen; `prevent_close` while locked stops the X from
+/// relaunching into an unlocked state.
+pub fn show_lock_window(app: &AppHandle) {
+    if let Some(w) = app.get_webview_window("lock") {
+        let _ = w.show();
+        let _ = w.set_focus();
+        return;
+    }
+    let built = WebviewWindowBuilder::new(app, "lock", WebviewUrl::App("lock.html".into()))
+        .title("whatRust — Locked")
+        .inner_size(420.0, 540.0)
+        .resizable(false)
+        .decorations(false)
+        .always_on_top(true)
+        .content_protected(true)
+        .center()
+        .focused(true)
+        .build();
+
+    if let Ok(win) = built {
+        let app_handle = app.clone();
+        win.on_window_event(move |event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                if !is_unlocked(&app_handle) {
+                    api.prevent_close();
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_hide_covers_accounts_and_settings() {
+        assert!(should_hide("wa-default"));
+        assert!(should_hide("wa-acct-3"));
+        assert!(should_hide("settings"));
+    }
+
+    #[test]
+    fn should_hide_never_hides_the_lock_window() {
+        assert!(!should_hide("lock"));
+    }
+
+    #[test]
+    fn is_lock_label_matches_only_lock() {
+        assert!(is_lock_label("lock"));
+        assert!(!is_lock_label("settings"));
+        assert!(!is_lock_label("wa-default"));
+    }
+}

--- a/src-tauri/src/lock.rs
+++ b/src-tauri/src/lock.rs
@@ -52,9 +52,11 @@ pub fn require_unlocked(app: &AppHandle) -> Result<(), String> {
 /// Lock the app: mark locked, hide every user-facing window (recording which were
 /// visible), and show the lock screen.
 pub fn lock_now(app: &AppHandle) {
-    if let Some(state) = app.try_state::<LockState>() {
-        *state.unlocked.lock().unwrap() = false;
-    }
+    let state = match app.try_state::<LockState>() {
+        Some(s) => s,
+        None => return, // not yet set up — bail
+    };
+    *state.unlocked.lock().unwrap() = false;
     let mut hidden = Vec::new();
     for (label, w) in app.webview_windows() {
         if should_hide(&label) && w.is_visible().unwrap_or(false) {
@@ -62,25 +64,22 @@ pub fn lock_now(app: &AppHandle) {
             hidden.push(label);
         }
     }
-    if let Some(state) = app.try_state::<LockState>() {
-        *state.hidden.lock().unwrap() = hidden;
-    }
+    *state.hidden.lock().unwrap() = hidden;
     show_lock_window(app);
 }
 
 /// Unlock the app: mark unlocked, destroy the lock window, and restore the windows
 /// that were visible when we locked (or fall back to the active account).
 pub fn unlock(app: &AppHandle) {
-    if let Some(state) = app.try_state::<LockState>() {
-        *state.unlocked.lock().unwrap() = true;
-    }
+    let state = match app.try_state::<LockState>() {
+        Some(s) => s,
+        None => return, // not yet set up — bail
+    };
+    *state.unlocked.lock().unwrap() = true;
     if let Some(w) = app.get_webview_window("lock") {
         let _ = w.destroy();
     }
-    let hidden = app
-        .try_state::<LockState>()
-        .map(|s| std::mem::take(&mut *s.hidden.lock().unwrap()))
-        .unwrap_or_default();
+    let hidden = std::mem::take(&mut *state.hidden.lock().unwrap());
     if hidden.is_empty() {
         crate::window::show_active(app);
     } else {
@@ -136,6 +135,7 @@ mod tests {
     #[test]
     fn should_hide_never_hides_the_lock_window() {
         assert!(!should_hide("lock"));
+        assert!(!should_hide("some-future-internal-panel"));
     }
 
     #[test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -48,8 +48,10 @@ pub fn save(app: &AppHandle, s: &Settings) -> tauri::Result<()> {
     Ok(())
 }
 
-/// Apply side effects of settings (autostart + global shortcut).
-pub fn apply(app: &AppHandle, s: &Settings) {
+/// Apply side effects of settings (autostart + global shortcut). Returns the global-
+/// shortcut registration error as `Some(msg)` if registering failed; `None` if it
+/// registered successfully, or the shortcut is disabled/empty, or on non-desktop.
+pub fn apply(app: &AppHandle, s: &Settings) -> Option<String> {
     #[cfg(desktop)]
     {
         use tauri_plugin_autostart::ManagerExt;
@@ -64,11 +66,18 @@ pub fn apply(app: &AppHandle, s: &Settings) {
         let gs = app.global_shortcut();
         let _ = gs.unregister_all();
         if s.hotkey_enabled && !s.hotkey.trim().is_empty() {
-            let _ = gs.register(s.hotkey.as_str());
+            return match gs.register(s.hotkey.as_str()) {
+                Ok(_) => None,
+                Err(e) => Some(e.to_string()),
+            };
         }
+        None
     }
     #[cfg(not(desktop))]
-    let _ = (app, s);
+    {
+        let _ = (app, s);
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -35,6 +35,11 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| {
             let id = event.id().as_ref();
+            // While locked, every menu action except Quit just (re)shows the lock screen.
+            if !crate::lock::is_unlocked(app) && id != "quit" {
+                crate::lock::show_lock_window(app);
+                return;
+            }
             if let Some(acct_id) = id.strip_prefix("acct:") {
                 crate::window::show_account(app, &accounts::window_label(acct_id));
                 return;
@@ -49,6 +54,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
                         }
                     }
                 }
+                "lock" => crate::lock::lock_now(app),
                 "quit" => app.exit(0),
                 _ => {}
             }
@@ -69,11 +75,13 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
 }
 
 /// Rebuild the tray menu from the current accounts list: one `acct:<id>` item per
-/// account showing `name (n)`, then the static `Accounts… / Settings / Reload / Quit`.
+/// account showing `name (n)`, then the static `Accounts… / Settings / Reload / [Lock now] / Quit`.
 pub fn rebuild_menu(app: &AppHandle) {
     let Some(tray) = app.tray_by_id("main-tray") else {
         return;
     };
+
+    let lock_active = crate::applock::load(app).is_active();
 
     let f = accounts::load(app);
 
@@ -117,14 +125,18 @@ pub fn rebuild_menu(app: &AppHandle) {
         return;
     };
 
-    let menu = match builder
+    let mut tail = builder
         .separator()
         .item(&accounts_item)
         .item(&settings)
-        .item(&reload)
-        .item(&quit)
-        .build()
-    {
+        .item(&reload);
+    if lock_active {
+        let Ok(lock_item) = MenuItemBuilder::with_id("lock", "Lock now").build(app) else {
+            return;
+        };
+        tail = tail.item(&lock_item);
+    }
+    let menu = match tail.item(&quit).build() {
         Ok(m) => m,
         Err(_) => return,
     };

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -231,6 +231,12 @@ pub fn show_account(app: &AppHandle, label: &str) {
 /// Show the active (last-focused) account window. Falls back to the first existing
 /// account window, then the settings window.
 pub fn show_active(app: &AppHandle) {
+    // If the app is locked, any "reveal" request shows the lock screen, never an
+    // account window. Covers tray click, global shortcut, single-instance, macOS Reopen.
+    if !crate::lock::is_unlocked(app) {
+        crate::lock::show_lock_window(app);
+        return;
+    }
     if let Some(active) = app.try_state::<ActiveAccount>() {
         let label = active.lock().unwrap().clone();
         if app.get_webview_window(&label).is_some() {

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -46,7 +46,10 @@ pub fn open_account_window(
     win.on_window_event(move |event| {
         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
             if crate::settings::load(&app_handle).close_to_tray {
-                if let Some(w) = app_handle.get_webview_window(&label_for_close) {
+                let lc = crate::applock::load(&app_handle);
+                if lc.is_active() && lc.lock_on_hide {
+                    crate::lock::lock_now(&app_handle);
+                } else if let Some(w) = app_handle.get_webview_window(&label_for_close) {
                     let _ = w.hide();
                 }
                 api.prevent_close();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "whatRust",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.karem.whatrust",
   "build": {
     "frontendDist": "../settings-ui"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,13 @@
     "macOS": {
       "minimumSystemVersion": "12.0"
     },
+    "linux": {
+      "deb": {
+        "files": {
+          "/usr/share/polkit-1/actions/com.karem.whatrust.policy": "resources/com.karem.whatrust.policy"
+        }
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary
Two features since v0.2.0, plus the v0.3.0 release bump.

**Optional app lock** (`docs/superpowers/specs/2026-06-01-app-lock-design.md`)
- Argon2id password baseline (all platforms) + optional biometric: Windows Hello, macOS Touch ID, Linux polkit.
- Lock on launch / on demand ("Lock now") / on hide-to-tray / on idle.
- Dedicated lock window; the real boundary is in-command `require_unlocked`/`is_lock_window` guards + capability scoping.
- Forgot-password reset wipes all sessions (logs out the default account too).
- Honest framing: access-control, not encryption-at-rest.

**Shortcut recorder** (`docs/superpowers/specs/2026-06-01-shortcut-recorder-design.md`)
- Set the global show/hide shortcut by pressing the combo (Record button), `event.code`-based.
- Requires a modifier (or an F-key); surfaces global-shortcut registration failures (previously swallowed).

## Test plan
- [x] `cargo test --lib` — 45 pass, warning-free
- [x] `node settings-ui/comboToAccelerator.test.mjs` — formatter unit tests pass
- [x] `check` workflow green on **Linux + Windows + macOS** (compile-verified the per-platform biometric code)
- [x] App-lock runtime smoke (Linux, headless): lock-on-launch, wrong/correct password, window restore
- [x] Recorder runtime smoke (headless Chrome DOM): record/validate/cancel all green
- [ ] Hardware-pending: Windows Hello prompt + macOS Touch ID prompt on real devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)