### PR TITLE
Wayland-friendly `--toggle` shortcut (v0.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The official WhatsApp Desktop app is built on Electron, which packs an entire Ch
 - **Persistent login** — scan the QR code once, stay signed in across restarts
 - **Voice messages, voice calls, and video calls** — microphone and camera support
 - **Launch at startup** (auto-start), optional
-- **Global keyboard shortcut** to show/hide the window (default `Ctrl/Cmd+Shift+W`)
-- **Single instance** — relaunching focuses the running window instead of opening a second
+- **Global keyboard shortcut** to show/hide the window (default `Ctrl/Cmd+Shift+W`; record your own by pressing the keys in Settings). On **Wayland**, bind `whatrust --toggle` to a system shortcut instead — see the FAQ.
+- **Single instance** — relaunching focuses the running window; `whatrust --toggle` from a second launch shows/hides it
 - **Remembers window size and position**
 - **One-line install** on every platform
 - **Cross-platform**: Linux, Windows, and macOS from one Rust + Tauri codebase
@@ -189,6 +189,15 @@ Yes. whatRust supports **multiple WhatsApp accounts** running at the same time �
 ### Does whatRust have an app lock?
 
 Yes. You can set a password under **Settings → Security** to require authentication before whatRust shows your chats. Biometric unlock (Windows Hello, Touch ID, or Linux polkit with an enrolled fingerprint) is an optional shortcut where the OS supports it. The lock controls window access — it does not encrypt data on disk (same posture as Signal Desktop). For at-rest protection use full-disk encryption.
+
+### The global show/hide shortcut doesn't work on my Linux desktop (Wayland)
+
+Wayland blocks apps from grabbing global hotkeys, so whatRust's built-in shortcut can't fire on a Wayland session (GNOME, KDE Plasma's Wayland, etc.) — this is a platform limitation, not specific to whatRust. The reliable approach is to let your desktop own the keybinding and have it toggle whatRust:
+
+1. **Settings → Keyboard → View and Customize Shortcuts → Custom Shortcuts → +** (GNOME; KDE has an equivalent under *Custom Shortcuts*)
+2. Name it `whatRust`, set the command to `whatrust --toggle`, and assign your key (e.g. `Ctrl+Shift+W`).
+
+`whatrust --toggle` shows the window if it's hidden and hides it if it's visible — a true toggle that works on Wayland. (The built-in shortcut still works on X11, Windows, and macOS.)
 
 ### Does whatRust support the system tray and close-to-tray?
 Yes. It adds a system tray icon with an unread-message badge, can close to the tray, and forwards new messages to native OS notifications.

--- a/settings-ui/index.html
+++ b/settings-ui/index.html
@@ -35,6 +35,7 @@
       </div>
     </label>
     <p id="hotkey_hint" class="hotkey-hint" hidden></p>
+    <p class="field-note">On Linux/Wayland the in-app shortcut can't fire (the desktop blocks global key grabs). Bind <code>whatrust --toggle</code> in your system keyboard settings instead — see the README.</p>
 
     <hr class="divider" />
     <h2 class="section-title">Security</h2>

--- a/settings-ui/style.css
+++ b/settings-ui/style.css
@@ -65,3 +65,6 @@ h2 { font-size: 14px; margin: 0 0 10px; font-weight: 600; }
 .hotkey-row #hotkey { flex: 1; min-width: 0; }
 #record_hotkey.recording { background: #f0a500; color: #1a1a1a; }
 .hotkey-hint { font-size: 12px; color: #f0a500; margin: 4px 0 0; }
+
+.field-note { font-size: 12px; color: #8696a0; margin: 4px 0 0; line-height: 1.4; }
+.field-note code { background: #8882; padding: 1px 5px; border-radius: 4px; font-size: 11px; }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "whatrust"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "argon2",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whatrust"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.82"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,10 +19,15 @@ pub fn run() {
     #[cfg(desktop)]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            // A 2nd launch normally raises the active account window — but NOT an
-            // autostart relaunch carrying --minimized (keep it hidden in the tray).
-            // show_main is a show_active shim (correction #5).
-            if !args.iter().any(|a| a == "--minimized") {
+            // `whatrust --toggle` (bind it to an OS keyboard shortcut — the reliable
+            // global-hotkey path on Wayland, where in-process X11 grabs don't fire)
+            // toggles the active window. Otherwise a 2nd launch raises it, except an
+            // autostart relaunch carrying --minimized (stay hidden in the tray).
+            // Both toggle_active and show_main defer to the lock screen when locked,
+            // so neither can bypass the app lock.
+            if args.iter().any(|a| a == "--toggle") {
+                window::toggle_active(app);
+            } else if !args.iter().any(|a| a == "--minimized") {
                 window::show_main(app);
             }
         }));
@@ -46,23 +51,10 @@ pub fn run() {
             .plugin(
                 tauri_plugin_global_shortcut::Builder::new()
                     .with_handler(|app, _shortcut, event| {
+                        // In-process global hotkey (X11 / Windows / macOS). On Wayland
+                        // this won't fire — use `whatrust --toggle` via an OS shortcut.
                         if event.state() == tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                            // Toggle the active account window.
-                            let label = app
-                                .try_state::<accounts::ActiveAccount>()
-                                .map(|a| a.lock().unwrap().clone());
-                            let visible = label
-                                .as_ref()
-                                .and_then(|l| app.get_webview_window(l))
-                                .map(|w| w.is_visible().unwrap_or(false));
-                            match (label, visible) {
-                                (Some(l), Some(true)) => {
-                                    if let Some(w) = app.get_webview_window(&l) {
-                                        let _ = w.hide();
-                                    }
-                                }
-                                _ => window::show_active(app),
-                            }
+                            window::toggle_active(app);
                         }
                     })
                     .build(),

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -270,6 +270,48 @@ pub fn show_main(app: &AppHandle) {
     show_active(app);
 }
 
+/// What a toggle should do given the active window's visibility.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ToggleAct {
+    Hide,
+    Show,
+}
+
+/// Pure toggle decision: a visible active window is hidden; anything else (a hidden
+/// window, or no active window at all → `None`) is shown.
+pub fn toggle_decision(active_visible: Option<bool>) -> ToggleAct {
+    match active_visible {
+        Some(true) => ToggleAct::Hide,
+        _ => ToggleAct::Show,
+    }
+}
+
+/// Toggle the active account window: hide it if visible, otherwise show + focus it.
+/// The "show" path goes through `show_active`, which defers to the lock screen when
+/// the app is locked — so a toggle (e.g. an OS-bound `whatrust --toggle` on Wayland,
+/// where in-process global hotkeys can't fire) can NEVER reveal an account window
+/// while locked. The "hide" path only triggers when an account window is visible,
+/// which cannot happen while locked.
+pub fn toggle_active(app: &AppHandle) {
+    let label = app
+        .try_state::<ActiveAccount>()
+        .map(|a| a.lock().unwrap().clone());
+    let visible = label
+        .as_ref()
+        .and_then(|l| app.get_webview_window(l))
+        .map(|w| w.is_visible().unwrap_or(false));
+    match toggle_decision(visible) {
+        ToggleAct::Hide => {
+            if let Some(l) = label {
+                if let Some(w) = app.get_webview_window(&l) {
+                    let _ = w.hide();
+                }
+            }
+        }
+        ToggleAct::Show => show_active(app),
+    }
+}
+
 /// Opens (or focuses) the local settings window.
 pub fn open_settings_window(app: &AppHandle) {
     if let Some(w) = app.get_webview_window("settings") {
@@ -282,4 +324,24 @@ pub fn open_settings_window(app: &AppHandle) {
         .inner_size(440.0, 680.0)
         .resizable(false)
         .build();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{toggle_decision, ToggleAct};
+
+    #[test]
+    fn visible_active_window_is_hidden() {
+        assert_eq!(toggle_decision(Some(true)), ToggleAct::Hide);
+    }
+
+    #[test]
+    fn hidden_active_window_is_shown() {
+        assert_eq!(toggle_decision(Some(false)), ToggleAct::Show);
+    }
+
+    #[test]
+    fn no_active_window_is_shown() {
+        assert_eq!(toggle_decision(None), ToggleAct::Show);
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "whatRust",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.karem.whatrust",
   "build": {
     "frontendDist": "../settings-ui"


### PR DESCRIPTION
## Summary
On Wayland the compositor blocks apps from grabbing global hotkeys, so whatRust's in-process global shortcut never fires there. This adds **`whatrust --toggle`**: a second launch forwards it via single-instance to toggle the active window (show if hidden, hide if visible). Users bind `whatrust --toggle` to an OS keyboard shortcut — the reliable Wayland path. The in-process shortcut still works on X11/Windows/macOS.

- New `window::toggle_active`, reused by the in-process global-shortcut handler (DRY).
- **Lock-safe by construction:** the show path goes through `show_active` (which defers to the lock screen when locked); the hide path only runs when a window is visible, which can't happen while locked. Verified an OS-bound toggle cannot bypass the app lock.
- README FAQ + Settings note explaining the Wayland binding.

## Test plan
- [x] `cargo test --lib` — 48 pass (3 new `toggle_decision` tests), warning-free
- [x] `check` CI green on Linux + Windows + macOS
- [x] Runtime (Xvfb + private session bus): `whatrust --toggle` forwards, **exits cleanly (rc=0, no zombie)**, toggles window IsViewable↔IsUnMapped
- [x] Adversarial review: no lock-bypass on any path

🤖 Generated with [Claude Code](https://claude.com/claude-code)