### PR TITLE
feat: drag-and-drop files & images into WhatsApp Web (v0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The official WhatsApp Desktop app is built on Electron, which packs an entire Ch
 - **Native OS notifications** for new messages
 - **Persistent login** — scan the QR code once, stay signed in across restarts
 - **Voice messages, voice calls, and video calls** — microphone and camera support
+- **Drag and drop files and images** — drop a photo, video, or document straight onto a chat to attach it
 - **Launch at startup** (auto-start), optional
 - **Global keyboard shortcut** to show/hide the window (default `Ctrl/Cmd+Shift+W`; record your own by pressing the keys in Settings). On **Wayland**, bind `whatrust --toggle` to a system shortcut instead — see the FAQ.
 - **Single instance** — relaunching focuses the running window; `whatrust --toggle` from a second launch shows/hides it

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "whatrust"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whatrust"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.82"
 

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -35,6 +35,19 @@ pub fn open_account_window(
         .icon(icon)?
         .user_agent(CHROME_UA)
         .initialization_script(BRIDGE_JS)
+        // Let WhatsApp Web receive dropped files/images. By default wry installs an
+        // OS-level drag-and-drop handler that swallows the native drop (firing
+        // `tauri://drag-drop` instead), so the page's HTML5 dragover/drop never fires
+        // and dropping a file does nothing. We don't use Tauri's drag-drop events, so
+        // disabling that handler lets the webview hand drops straight to web.whatsapp.com.
+        // This is also what makes HTML5 DnD work at all in WebView2 on Windows.
+        .disable_drag_drop_handler()
+        // Linux/webkit2gtk safety net: even with the OS handler off, a dropped file can
+        // make the webview *navigate* to its file:// URL (tauri#9725, #12052) — which
+        // would blow away the live WhatsApp session. WhatsApp Web never legitimately
+        // loads a file:// URL, so cancel any such navigation; the in-page HTML5 drop
+        // (which is what actually attaches the file) still fires.
+        .on_navigation(|url| url.scheme() != "file")
         .visible(!start_hidden);
 
     let builder = apply_isolation(builder, account, app);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "whatRust",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "identifier": "com.karem.whatrust",
   "build": {
     "frontendDist": "../settings-ui"


### PR DESCRIPTION
## What

Adds **drag-and-drop** of files and images into the WhatsApp Web window. Drop a photo, video, or document straight onto a chat to attach it — previously dropping a file did nothing.

## Why it didn't work

Account windows are built with Tauri v2's default OS-level drag-and-drop handler **enabled**. wry then swallows the native file drop (forwarding it as a `tauri://drag-drop` event) before WhatsApp Web's HTML5 drop zone can receive it. On WebView2 (Windows) wry additionally calls `SetAllowExternalDrop(false)` + registers a custom `IDropTarget`, fully blocking HTML5 DnD in the page.

## Fix (`src-tauri/src/window.rs`)

- `.disable_drag_drop_handler()` on the account `WebviewWindowBuilder` — we don't use Tauri-side drag-drop events, so this hands drops straight to `web.whatsapp.com`. This is the documented requirement for HTML5 DnD on Windows, and also restores it on Linux (webkit2gtk) and macOS (WKWebView).
- `.on_navigation(|url| url.scheme() != "file")` — guards against a known webkit2gtk bug (tauri#9725, #12052) where a dropped file can make the webview *navigate* to its `file://` URL and tear down the live session. WhatsApp Web never legitimately loads `file://` URLs.

## Verification

- `cargo build --locked` ✅ (Linux; CI covers Windows + macOS)
- `cargo test --locked` → 48/48 pass ✅
- Headless Xvfb launch ✅ — account window opens at 1100×800, no crash
- API confirmed against `tauri 2.11` / `wry 0.55` source (the versions in the tree)

End-to-end drop-to-attach should be confirmed manually on a logged-in session.

Releases as **v0.4.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)