### PR TITLE
[loop cycle 2] fix(notifications): forward service-worker showNotification to native toast

### DIFF
--- a/src-tauri/resources/bridge.js
+++ b/src-tauri/resources/bridge.js
@@ -66,6 +66,34 @@
     window.Notification = ShimNotification;
   } catch (e) {}
 
+  // 2b) Service-worker notification path. Modern WhatsApp Web also raises notifications
+  //     via ServiceWorkerRegistration.showNotification (e.g. when the tab is backgrounded),
+  //     which the window.Notification shim above does NOT intercept — so those toasts never
+  //     reached the OS. Override the page-side prototype method to forward through the same
+  //     native `notify` command, and report an empty list from getNotifications (we render a
+  //     native toast, so there is no in-page Notification object to hand back). We can only
+  //     reach the page's prototype here; notifications fired from inside the service worker's
+  //     own context are out of scope for a page-injected script.
+  try {
+    var SWR = window.ServiceWorkerRegistration;
+    if (SWR && SWR.prototype && typeof SWR.prototype.showNotification === "function") {
+      SWR.prototype.showNotification = function (title, options) {
+        options = options || {};
+        invoke("notify", {
+          title: String(title || "WhatsApp"),
+          body: String(options.body || ""),
+        });
+        // Real API resolves Promise<undefined>; match it so callers awaiting it don't break.
+        return Promise.resolve();
+      };
+      if (typeof SWR.prototype.getNotifications === "function") {
+        SWR.prototype.getNotifications = function () {
+          return Promise.resolve([]);
+        };
+      }
+    }
+  } catch (e) {}
+
   // 3) Unread count — forward the raw <title> string on change; Rust parses it.
   var lastTitle = "";
   function report() {


### PR DESCRIPTION
## What

Fixes a class of **missing notifications**. WhatsApp Web raises some notifications through the **service worker** via `ServiceWorkerRegistration.showNotification(...)` (used when it treats the tab as backgrounded). The existing `window.Notification` shim only intercepts the page-side `new Notification(...)` constructor — so the service-worker path slipped past it and those notifications never reached the OS notification center.

## How

In `bridge.js` (section 2b, right after the existing Notification shim), override the page-side `ServiceWorkerRegistration.prototype.showNotification` to forward through the **same native `notify` command** the constructor shim already uses, and stub `getNotifications()` to resolve to `[]` (we render native toasts, so there's no in-page Notification object to return).

- Installed as a Tauri `initialization_script`, so it runs **before any page JS** → WhatsApp can't capture a pre-patch reference; prototype lookup at call time means instances created later are covered.
- Origin-guarded (whole file is gated to `https://web.whatsapp.com`) and wrapped in its **own try/catch**, so it can never abort the rest of `bridge.js`.
- Routes through `commands::notify`, inheriting its **lock-screen and settings suppression** unchanged.
- Scope is honest: notifications fired from inside the service worker's *own* realm can't be reached by a page-injected script (documented in the comment).

## Verification

**Gate 1 — deterministic (`cargo build --locked` + `cargo test`):** PASS (51 tests; bridge.js is embedded via `include_str!`).

**Gate 2 — real-engine behavioral (PyGObject WebKitGTK 2.x harness, origin spoofed to web.whatsapp.com):** PASS. With a `__TAURI__.invoke` recorder installed:
- `new Notification("DM from Sara",{body:"hey there"})` → 1 `notify` invoke ✅
- `reg.showNotification("Group: Family",{body:"3 new messages"})` → 1 `notify` invoke ✅
- `showNotification` returns a Promise ✅ · `getNotifications()` → `[]` ✅ · `Notification.permission === "granted"` ✅ (no regression to the existing path)

**Gate 3 — generation-blind code review (separate `feature-dev:code-reviewer`):** APPROVE, severity none, no must-fix. Confirmed: override timing prevents a pre-patch reference; both paths inherit identical Rust-side suppression; try/catch isolated; `getNotifications` stub redundant-but-harmless; tag-dedup absence is pre-existing (matches the `window.Notification` shim), not a regression.

---
🤖 **PR-ONLY — do not auto-merge.** Releasing whatRust is manual via a `v*` tag; this loop never merges, bumps the version, or tags a release. Opened by the `whatrust-fix-loop` (cycle 2/6).