### PR TITLE
[loop cycle 3] feat(calls): expose minimal window.chrome so WhatsApp enables call buttons

### DIFF
--- a/src-tauri/resources/bridge.js
+++ b/src-tauri/resources/bridge.js
@@ -38,6 +38,23 @@
     }
   } catch (e) {}
 
+  // 1b) Chrome environment marker — enables voice/video CALLING. WhatsApp Web gates
+  //     calling behind a Chrome/Edge eligibility check that, beyond the UA and
+  //     userAgentData (both already spoofed above), probes for `window.chrome`. WebKitGTK
+  //     ships WebRTC (so calls CAN work once eligible) but exposes no `window.chrome`, so
+  //     the call buttons stay disabled. Add a minimal, idempotent stand-in matching what a
+  //     real Chrome minimally exposes; never clobber a genuine `window.chrome`.
+  try {
+    if (!window.chrome) {
+      Object.defineProperty(window, "chrome", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: { app: { isInstalled: false }, runtime: {} },
+      });
+    }
+  } catch (e) {}
+
   // 2) Notification override — forward to a native OS notification via Rust.
   try {
     function ShimNotification(title, options) {


### PR DESCRIPTION
## What

Targets **"calls are not supported."** WhatsApp Web disables the voice/video **call buttons** unless it judges the environment an eligible Chrome/Edge browser. The UA and `navigator.userAgentData` already report Chrome 131, but the calling-eligibility check **also probes `window.chrome`**, which WebKitGTK doesn't expose — so the buttons stay greyed.

Crucially, this is a **detection** gate, not a capability one: it was verified that this WebKitGTK build (**2.52.3**) **ships WebRTC** (libwebrtc codec symbols + `enable-webrtc` present), and the app already enables it and auto-grants mic/camera (`enable_webview_media` in `window.rs`). So the engine *can* do calls once WhatsApp considers it eligible.

## How

`bridge.js` section 1b adds a minimal, idempotent stand-in:

```js
if (!window.chrome) {
  Object.defineProperty(window, "chrome", {
    configurable: true, enumerable: true, writable: true,
    value: { app: { isInstalled: false }, runtime: {} },
  });
}
```

- `app.isInstalled:false` is exactly what a normal web page in real Chrome sees — it steers WhatsApp **away** from the Chrome-Apps path, not into it.
- `runtime:{}` satisfies a `typeof chrome.runtime` probe without exposing callable extension APIs.
- Origin-guarded, own try/catch, never clobbers a genuine `window.chrome`.

## Verification

**Gate 1 — `cargo build --locked` + `cargo test`:** PASS (51 tests).

**Gate 2 — real WebKitGTK engine harness (origin spoofed), two cases:** PASS
- *absent* → `window.chrome` becomes an object with `runtime` + `app.isInstalled===false`; userAgentData (3 brands) + Notification shim intact.
- *preset* (`{__sentinel:"real"}`) → sentinel **preserved** (no clobber); existing shims intact.

**Gate 3 — generation-blind code review:** APPROVE, severity none, no must-fix. Confirmed the no-clobber guard, descriptor flags matching real Chrome, **low regression risk** (minimal stub avoids triggering extension/Chrome-App code paths), isolation, and idempotency.

## ⚠ Human-test gate (please confirm before merging)

The call button can't be exercised headlessly — it needs a **logged-in WhatsApp**. Before merging, please:
1. Build/run this branch, open a chat, and check whether the **voice/video call icons are now enabled** (no longer greyed).
2. Optionally start a call to confirm mic/camera negotiate.

If the buttons are **still disabled**, this wasn't the (only) gate — the next lever is WebRTC **codec** availability (H264/VP8) in this WebKitGTK build, tracked as backlog **C2**. Either way this change is safe and reversible (it only adds a Chrome marker).

---
🤖 **PR-ONLY — do not auto-merge.** Releasing whatRust is manual via a `v*` tag; this loop never merges, bumps the version, or tags a release. Opened by the `whatrust-fix-loop` (cycle 3/6).