### PR TITLE
[loop cycle 4] fix(notifications): de-duplicate burst-repeated native toasts

### DIFF
--- a/src-tauri/resources/bridge.js
+++ b/src-tauri/resources/bridge.js
@@ -10,6 +10,28 @@
     return Promise.resolve();
   }
 
+  // Native OS toast with short-window de-duplication. WhatsApp can raise the same alert
+  // more than once in a burst (a React re-render, or one message surfacing through two
+  // notification code paths), and unlike a browser (which collapses repeats by tag) a
+  // native toast stacks every call as a separate visible popup. Suppress an identical
+  // title+body seen within DEDUP_MS; genuinely different messages are never affected.
+  // Returns true if forwarded, false if suppressed as a duplicate.
+  var DEDUP_MS = 3500;
+  var recentNotif = Object.create(null);
+  function nativeNotify(title, body) {
+    title = String(title || "WhatsApp");
+    body = String(body || "");
+    var now = Date.now();
+    for (var k in recentNotif) {
+      if (now - recentNotif[k] > DEDUP_MS) delete recentNotif[k]; // prune stale keys
+    }
+    var key = title + " " + body;
+    if (recentNotif[key] && now - recentNotif[key] <= DEDUP_MS) return false;
+    recentNotif[key] = now;
+    invoke("notify", { title: title, body: body });
+    return true;
+  }
+
   // 1) Client Hints shim — navigator.userAgentData is undefined in WebKitGTK,
   //    which WhatsApp's capability check can trip over.
   try {
@@ -48,10 +70,7 @@
       this.onclose = null;
       this.onerror = null;
       this.onshow = null;
-      invoke("notify", {
-        title: String(title || "WhatsApp"),
-        body: String(options.body || ""),
-      });
+      nativeNotify(title, options.body);
     }
     ShimNotification.prototype.close = function () {
       if (typeof this.onclose === "function") this.onclose();


### PR DESCRIPTION
## What

Stops the **same notification showing up two or three times**. WhatsApp can raise the same alert more than once in a quick burst (a React re-render, or one message surfacing through two notification code paths). A browser collapses those by `tag`, but a native OS toast stacks every call as a separate visible popup.

## How

Add a `nativeNotify(title, body)` helper that suppresses an identical `title+body` seen within a **3500ms** window (pruning stale keys each call so the map stays bounded), and route the `window.Notification` shim through it.

- Distinct messages — including *different* messages from the same chat — are never suppressed.
- An identical alert is allowed again once the window expires.
- Title/body coercion is unchanged; lock/settings suppression still happens downstream in the Rust `notify` command.
- Map is `Object.create(null)` (no prototype-key hazards).

## Verification

**Gate 1 — `cargo build --locked` + `cargo test`:** PASS (51 tests; bridge embedded via `include_str!`).

**Gate 2 — real WebKitGTK engine harness (origin spoofed, `invoke` recorder):** PASS
- 5 fires, 2 identical immediate duplicates → **3** native notifies
- distinct title/body messages all delivered
- the same alert **re-fires** after the 3500ms window expires (4 total)

**Gate 3 — generation-blind code review:** APPROVE, severity none, no must-fix. Confirmed dedup correctness, `Object.create(null)` key safety, safe `for..in`+delete prune, strict-mode legality, behavior parity.

> 🐞 **A latent crash was caught and fixed during this cycle.** An earlier iteration used a **NUL byte** as the dedup-key separator. JS string literals can contain NUL, so `node --check` passed — but the script is handed to WebKit as a **C string**, so the NUL truncated the *entire* injected `bridge.js` at that line (which would have silently broken drag-drop, unread counts, and notifications in the real app). The real-engine harness surfaced it; the separator is now a plain space and the file is pure ASCII.

---
🤖 **PR-ONLY — do not auto-merge.** Releasing whatRust is manual via a `v*` tag; this loop never merges, bumps the version, or tags a release. Opened by the `whatrust-fix-loop` (cycle 4/6).