### PR TITLE
[loop cycle 6] fix(calls/capability): complete the Chrome high-entropy client-hints set

### DIFF
--- a/src-tauri/resources/bridge.js
+++ b/src-tauri/resources/bridge.js
@@ -24,13 +24,31 @@
           ],
           mobile: false,
           platform: "Linux",
+          // Real Chrome returns the requested hints (and these fields are what WhatsApp's
+          // capability/calling check reads). The previous shim omitted bitness,
+          // fullVersionList and wow64 and left platformVersion empty, which a strict check
+          // can treat as "not Chrome". Return the full, internally-consistent set; returning
+          // hints that weren't asked for is harmless.
           getHighEntropyValues: function () {
             return Promise.resolve({
-              platform: "Linux",
-              platformVersion: "",
               architecture: "x86",
+              bitness: "64",
+              brands: [
+                { brand: "Chromium", version: "131" },
+                { brand: "Google Chrome", version: "131" },
+                { brand: "Not_A Brand", version: "24" },
+              ],
+              fullVersionList: [
+                { brand: "Chromium", version: "131.0.0.0" },
+                { brand: "Google Chrome", version: "131.0.0.0" },
+                { brand: "Not_A Brand", version: "24.0.0.0" },
+              ],
+              mobile: false,
               model: "",
+              platform: "Linux",
+              platformVersion: "6.0.0",
               uaFullVersion: "131.0.0.0",
+              wow64: false,
             });
           },
         },


### PR DESCRIPTION
## What

Hardens the Chrome **capability/calling detection**. The `navigator.userAgentData` shim's `getHighEntropyValues()` returned only a partial set and left `platformVersion` empty. A strict check (the kind WhatsApp uses to decide capability and **calling eligibility**) reads `bitness`, `fullVersionList`, and `wow64` — their absence, plus an empty `platformVersion`, can read as "not a real Chrome UA-CH implementation."

This complements cycle 3 (`window.chrome`): together they present a consistent Chrome identity.

## How

Return the full, internally-consistent set matching the spoofed Chrome 131 UA:

| field | value |
|---|---|
| architecture | `x86` (Chrome reports x86 for x86_64) |
| bitness | `64` |
| brands | major versions (`131`) |
| fullVersionList | full versions (`131.0.0.0`) |
| mobile / model | `false` / `""` |
| platform / platformVersion | `Linux` / `6.0.0` |
| uaFullVersion / wow64 | `131.0.0.0` / `false` |

The `hints` argument is intentionally ignored (the shim *is* the implementation); returning unrequested keys is harmless. Top-level `brands`/`mobile`/`platform` are unchanged.

## Verification

**Gate 1 — `cargo build --locked` + `cargo test`:** PASS (51 tests).

**Gate 2 — real WebKitGTK engine harness (origin spoofed):** PASS — `getHighEntropyValues([...])` resolves with `bitness:"64"`, `wow64:false`, `fullVersionList` length 3 (Chrome `131.0.0.0`), `platformVersion:"6.0.0"`, `uaFullVersion:"131.0.0.0"`; top-level shim still reports 3 brands, mobile false, platform Linux.

**Gate 3 — generation-blind code review:** APPROVE, severity none, no must-fix. Confirmed `architecture:"x86"` per WICG spec, the major-vs-full version split matches real Chrome, the new fields are correct for Linux x86_64, valid object literal (no duplicate keys, no NUL), and **no regression** (additions only make the identity more Chrome-like).

---
🤖 **PR-ONLY — do not auto-merge.** Releasing whatRust is manual via a `v*` tag; this loop never merges, bumps the version, or tags a release. Opened by the `whatrust-fix-loop` (cycle 6/6 — final).