### PR TITLE
fix(settings-ui): replace the native JS dialogs, which do nothing on macOS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,3 +53,9 @@ jobs:
 
       - name: settings-ui hotkey tests
         run: node settings-ui/comboToAccelerator.test.mjs
+
+      # The in-page dialogs replace alert/confirm/prompt, which do nothing under
+      # WKWebView. A regression here is invisible on Linux and Windows CI runners
+      # and shows up only as a dead button on macOS, so it needs a test.
+      - name: settings-ui dialog tests
+        run: node settings-ui/dialog.test.mjs

--- a/settings-ui/dialog.css
+++ b/settings-ui/dialog.css
@@ -1,0 +1,37 @@
+/* In-page replacements for window.alert/confirm/prompt. Shared by the settings
+   window and the lock screen, so the styles stand on their own rather than
+   extending either page's sheet. */
+.dlg-backdrop {
+  position: fixed; inset: 0; z-index: 100;
+  display: flex; align-items: center; justify-content: center; padding: 24px;
+  background: #000a;
+}
+.dlg-backdrop[hidden] { display: none; }
+.dlg {
+  width: 100%; max-width: 340px; padding: 20px;
+  border-radius: 12px; box-shadow: 0 14px 44px #0007;
+  background: #fff; color: #111b21;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px; text-align: left;
+}
+@media (prefers-color-scheme: dark) {
+  .dlg { background: #202c33; color: #e9edef; }
+}
+.dlg h2 { font-size: 15px; font-weight: 600; margin: 0 0 8px; }
+.dlg-message { margin: 0; line-height: 1.45; white-space: pre-line; }
+.dlg-input {
+  width: 100%; margin-top: 14px; padding: 9px 11px; font-size: 14px;
+  border: 1px solid #8886; border-radius: 8px;
+  background: transparent; color: inherit;
+}
+.dlg-input:focus { outline: 2px solid #25d36688; outline-offset: 1px; }
+.dlg-error { color: #f15c6d; font-size: 13px; margin: 8px 0 0; }
+.dlg-error[hidden] { display: none; }
+.dlg-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
+.dlg-actions button {
+  padding: 8px 16px; font-size: 14px; font-weight: 600;
+  border: 0; border-radius: 8px; cursor: pointer;
+  background: #25d366; color: #042f1a;
+}
+.dlg-actions button.dlg-secondary { background: transparent; color: inherit; border: 1px solid #8886; }
+.dlg-actions button.dlg-danger { background: #e5484d; color: #fff; }

--- a/settings-ui/dialog.js
+++ b/settings-ui/dialog.js
@@ -1,0 +1,149 @@
+// In-page alert / confirm / prompt.
+//
+// The native ones cannot be used here. WKWebView only shows a JavaScript dialog
+// if the host implements the matching WKUIDelegate panel method, and wry
+// implements none of them, so on macOS `alert()` does nothing, `confirm()`
+// returns false, and `prompt()` returns null — all without ever drawing
+// anything. Rename, Remove, Change password, Disable lock and the reset link
+// therefore looked like dead buttons on macOS while working on Windows and
+// Linux, whose webviews answer these calls natively.
+//
+// These replacements are page elements, so they behave the same everywhere.
+// They are async: `await Dlg.confirm(...)`, not `if (confirm(...))`.
+(function () {
+  "use strict";
+
+  var open = null; // { resolve, cancel } for the dialog currently on screen
+
+  function el(tag, className, text) {
+    var e = document.createElement(tag);
+    if (className) e.className = className;
+    if (text !== undefined) e.textContent = text;
+    return e;
+  }
+
+  function close(result) {
+    if (!open) return;
+    var o = open;
+    open = null;
+    document.removeEventListener("keydown", onKeydown, true);
+    o.backdrop.remove();
+    if (o.restoreFocus && document.contains(o.restoreFocus)) o.restoreFocus.focus();
+    o.resolve(result);
+  }
+
+  function onKeydown(e) {
+    if (!open) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close(open.cancelValue);
+    } else if (e.key === "Enter" && e.target.tagName !== "BUTTON") {
+      e.preventDefault();
+      open.accept();
+    } else if (e.key === "Tab") {
+      // Keep focus inside the dialog: it is modal in intent, and a Tab that
+      // escapes it lands on controls the dialog is covering.
+      var f = open.focusable;
+      if (f.length < 2) return;
+      var first = f[0];
+      var last = f[f.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  // kind: "alert" | "confirm" | "prompt"
+  function show(kind, message, opts) {
+    opts = opts || {};
+    if (open) close(open.cancelValue); // one at a time; the newer call wins
+
+    var backdrop = el("div", "dlg-backdrop");
+    var box = el("div", "dlg");
+    box.setAttribute("role", "dialog");
+    box.setAttribute("aria-modal", "true");
+
+    if (opts.title) {
+      var h = el("h2", null, opts.title);
+      box.appendChild(h);
+    }
+    if (message) box.appendChild(el("p", "dlg-message", message));
+
+    var input = null;
+    if (kind === "prompt") {
+      input = el("input", "dlg-input");
+      input.type = opts.password ? "password" : "text";
+      input.value = opts.value || "";
+      if (opts.password) input.autocomplete = "off";
+      if (opts.placeholder) input.placeholder = opts.placeholder;
+      box.appendChild(input);
+    }
+
+    var error = el("p", "dlg-error");
+    error.hidden = true;
+    box.appendChild(error);
+
+    var actions = el("div", "dlg-actions");
+    var cancel = null;
+    if (kind !== "alert") {
+      cancel = el("button", "dlg-secondary", opts.cancelLabel || "Cancel");
+      cancel.type = "button";
+      actions.appendChild(cancel);
+    }
+    var ok = el("button", opts.danger ? "dlg-danger" : null, opts.okLabel || "OK");
+    ok.type = "button";
+    actions.appendChild(ok);
+    box.appendChild(actions);
+    backdrop.appendChild(box);
+
+    var cancelValue = kind === "confirm" ? false : kind === "prompt" ? null : undefined;
+
+    return new Promise(function (resolve) {
+      function accept() {
+        if (kind !== "prompt") return close(kind === "confirm" ? true : undefined);
+        // Never trim a password: leading or trailing whitespace is part of it.
+        var v = opts.password ? input.value : input.value.trim();
+        if (opts.required !== false && !v) {
+          error.textContent = opts.requiredMessage || "This cannot be empty.";
+          error.hidden = false;
+          input.focus();
+          return;
+        }
+        close(v);
+      }
+
+      open = {
+        resolve: resolve,
+        backdrop: backdrop,
+        accept: accept,
+        cancelValue: cancelValue,
+        restoreFocus: document.activeElement,
+        focusable: cancel ? [input, cancel, ok].filter(Boolean) : [ok],
+      };
+
+      ok.addEventListener("click", accept);
+      if (cancel) cancel.addEventListener("click", function () { close(cancelValue); });
+      backdrop.addEventListener("mousedown", function (e) {
+        if (e.target === backdrop) close(cancelValue);
+      });
+      document.addEventListener("keydown", onKeydown, true);
+
+      document.body.appendChild(backdrop);
+      (input || ok).focus();
+      if (input) input.select();
+    });
+  }
+
+  window.Dlg = {
+    /** Resolves when dismissed. */
+    alert: function (message, opts) { return show("alert", message, opts); },
+    /** Resolves true only if confirmed. */
+    confirm: function (message, opts) { return show("confirm", message, opts); },
+    /** Resolves to the entered text (trimmed unless `password`), or null if cancelled. */
+    prompt: function (message, opts) { return show("prompt", message, opts); },
+  };
+})();

--- a/settings-ui/dialog.test.mjs
+++ b/settings-ui/dialog.test.mjs
@@ -1,0 +1,275 @@
+// Zero-dependency behavioral tests for dialog.js, the in-page replacement for
+// window.alert/confirm/prompt. Run: node settings-ui/dialog.test.mjs
+// Exits nonzero on failure. Same standalone pattern as bridge.test.mjs.
+//
+// These exist because the native dialogs silently do nothing under WKWebView
+// (wry implements no WKUIDelegate JS panel methods), which is invisible on
+// Windows and Linux: a regression here would look like a dead button on macOS
+// only. The harness stubs the DOM surface dialog.js touches, evals the real
+// script, and drives it through clicks and key events.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dialogSrc = readFileSync(join(here, "dialog.js"), "utf8");
+
+let failures = 0;
+function assert(cond, msg) {
+  if (cond) {
+    console.log("  ok  " + msg);
+  } else {
+    failures++;
+    console.error("FAIL  " + msg);
+  }
+}
+const settled = () => new Promise((r) => setTimeout(r, 0));
+
+// --- minimal DOM stubs -------------------------------------------------------
+
+class FakeNode {
+  constructor(tag, doc) {
+    this.tagName = tag.toUpperCase();
+    this.doc = doc;
+    this.children = [];
+    this.parent = null;
+    this.listeners = Object.create(null);
+    this.className = "";
+    this.textContent = "";
+    this.hidden = false;
+    this.value = "";
+    this.attrs = Object.create(null);
+  }
+  appendChild(child) {
+    child.parent = this;
+    this.children.push(child);
+    return child;
+  }
+  remove() {
+    if (!this.parent) return;
+    this.parent.children = this.parent.children.filter((c) => c !== this);
+    this.parent = null;
+  }
+  setAttribute(k, v) { this.attrs[k] = v; }
+  addEventListener(type, fn) { (this.listeners[type] ||= []).push(fn); }
+  removeEventListener(type, fn) {
+    this.listeners[type] = (this.listeners[type] || []).filter((f) => f !== fn);
+  }
+  dispatch(type, event) {
+    for (const fn of this.listeners[type] || []) fn({ target: this, preventDefault() {}, ...event });
+  }
+  focus() { this.doc.activeElement = this; }
+  select() {}
+  /** Depth-first search by class name, for the test's own assertions. */
+  find(cls) {
+    if (String(this.className).split(" ").includes(cls)) return this;
+    for (const c of this.children) {
+      const hit = c.find(cls);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  contains(node) {
+    if (node === this) return true;
+    return this.children.some((c) => c.contains(node));
+  }
+}
+
+function makeHarness() {
+  const doc = {
+    listeners: Object.create(null),
+    createElement(tag) { return new FakeNode(tag, doc); },
+    addEventListener(type, fn) { (doc.listeners[type] ||= []).push(fn); },
+    removeEventListener(type, fn) {
+      doc.listeners[type] = (doc.listeners[type] || []).filter((f) => f !== fn);
+    },
+    contains(node) { return doc.body.contains(node); },
+    /** Fire a document-level key event the way the capture listener sees it. */
+    key(key, extra) {
+      const target = doc.activeElement || doc.body;
+      for (const fn of doc.listeners.keydown || []) {
+        fn({ key, target, shiftKey: false, preventDefault() {}, ...extra });
+      }
+    },
+  };
+  doc.body = new FakeNode("body", doc);
+  doc.activeElement = doc.body;
+
+  const window = { document: doc };
+  const fn = new Function("window", "document", `"use strict";\n${dialogSrc}`);
+  fn(window, doc);
+  return { window, doc, Dlg: window.Dlg };
+}
+
+/** The backdrop of the dialog currently on screen, or null. */
+const backdropOf = (doc) => doc.body.children.find((c) => c.className === "dlg-backdrop") || null;
+const buttons = (doc) => backdropOf(doc).find("dlg-actions").children;
+const clickOk = (doc) => { const b = buttons(doc); b[b.length - 1].dispatch("click"); };
+const clickCancel = (doc) => buttons(doc)[0].dispatch("click");
+
+// --- tests -------------------------------------------------------------------
+
+async function testAlertResolvesOnDismiss() {
+  console.log("alert shows one button and resolves when dismissed");
+  const { doc, Dlg } = makeHarness();
+  let done = false;
+  const p = Dlg.alert("Something failed.", { title: "Oops" }).then(() => (done = true));
+  await settled();
+  assert(!!backdropOf(doc), "dialog is on screen");
+  assert(buttons(doc).length === 1, "alert has no Cancel button");
+  assert(!done, "does not resolve before dismissal");
+  clickOk(doc);
+  await p;
+  assert(done, "resolves after OK");
+  assert(!backdropOf(doc), "dialog removed from the page");
+}
+
+async function testConfirmOutcomes() {
+  console.log("confirm resolves true only when confirmed");
+  const { doc, Dlg } = makeHarness();
+
+  let p = Dlg.confirm("Remove it?");
+  await settled();
+  clickOk(doc);
+  assert((await p) === true, "OK resolves true");
+
+  p = Dlg.confirm("Remove it?");
+  await settled();
+  clickCancel(doc);
+  assert((await p) === false, "Cancel resolves false");
+
+  p = Dlg.confirm("Remove it?");
+  await settled();
+  doc.key("Escape");
+  assert((await p) === false, "Escape resolves false");
+
+  p = Dlg.confirm("Remove it?");
+  await settled();
+  const backdrop = backdropOf(doc);
+  backdrop.dispatch("mousedown", { target: backdrop });
+  assert((await p) === false, "clicking outside resolves false");
+}
+
+async function testConfirmIgnoresClicksInsideTheBox() {
+  console.log("a click on the dialog body does not dismiss it");
+  const { doc, Dlg } = makeHarness();
+  const p = Dlg.confirm("Remove it?");
+  await settled();
+  const backdrop = backdropOf(doc);
+  backdrop.dispatch("mousedown", { target: backdrop.children[0] });
+  await settled();
+  assert(!!backdropOf(doc), "still on screen");
+  clickCancel(doc);
+  await p;
+}
+
+async function testPromptReturnsTextOrNull() {
+  console.log("prompt returns the entered text, or null when cancelled");
+  const { doc, Dlg } = makeHarness();
+
+  let p = Dlg.prompt("", { title: "Rename account", value: "Work" });
+  await settled();
+  const input = backdropOf(doc).find("dlg-input");
+  assert(input.value === "Work", "prefilled with the current value");
+  assert(input.type === "text", "plain text input by default");
+  input.value = "  Personal  ";
+  clickOk(doc);
+  assert((await p) === "Personal", "resolves the trimmed text");
+
+  p = Dlg.prompt("", { title: "Rename account", value: "Work" });
+  await settled();
+  clickCancel(doc);
+  assert((await p) === null, "Cancel resolves null, distinct from an empty string");
+
+  p = Dlg.prompt("", { title: "Rename account", value: "Work" });
+  await settled();
+  doc.key("Escape");
+  assert((await p) === null, "Escape resolves null");
+}
+
+async function testEnterAccepts() {
+  console.log("Enter in the text field accepts");
+  const { doc, Dlg } = makeHarness();
+  const p = Dlg.prompt("", { title: "Rename account", value: "Work" });
+  await settled();
+  backdropOf(doc).find("dlg-input").value = "Family";
+  doc.key("Enter");
+  assert((await p) === "Family", "Enter resolves the value");
+}
+
+async function testEmptyInputIsRefusedNotResolved() {
+  console.log("an empty required field blocks instead of resolving empty");
+  const { doc, Dlg } = makeHarness();
+  let resolved;
+  const p = Dlg.prompt("", { title: "Rename account", value: "Work" }).then((v) => (resolved = v));
+  await settled();
+  const input = backdropOf(doc).find("dlg-input");
+  input.value = "   ";
+  clickOk(doc);
+  await settled();
+  assert(resolved === undefined, "does not resolve");
+  assert(!!backdropOf(doc), "dialog stays open");
+  assert(backdropOf(doc).find("dlg-error").hidden === false, "an error is shown");
+  input.value = "Family";
+  clickOk(doc);
+  await p;
+  assert(resolved === "Family", "resolves once a name is given");
+}
+
+async function testPasswordIsNotTrimmed() {
+  console.log("a password keeps its surrounding whitespace");
+  const { doc, Dlg } = makeHarness();
+  const p = Dlg.prompt("", { title: "Current password", password: true });
+  await settled();
+  const input = backdropOf(doc).find("dlg-input");
+  assert(input.type === "password", "masked input");
+  input.value = " hunter2 ";
+  clickOk(doc);
+  assert((await p) === " hunter2 ", "value passed through untrimmed");
+}
+
+async function testFocusIsRestored() {
+  console.log("focus returns to whatever opened the dialog");
+  const { doc, Dlg } = makeHarness();
+  const opener = doc.createElement("button");
+  doc.body.appendChild(opener);
+  opener.focus();
+  const p = Dlg.confirm("Remove it?");
+  await settled();
+  assert(doc.activeElement !== opener, "focus moves into the dialog");
+  clickCancel(doc);
+  await p;
+  assert(doc.activeElement === opener, "focus restored to the opener");
+}
+
+async function testKeyListenerIsReleased() {
+  console.log("the document key listener is removed when the dialog closes");
+  const { doc, Dlg } = makeHarness();
+  const p = Dlg.confirm("Remove it?");
+  await settled();
+  assert((doc.listeners.keydown || []).length === 1, "listener attached while open");
+  clickCancel(doc);
+  await p;
+  assert((doc.listeners.keydown || []).length === 0, "listener detached after close");
+}
+
+const tests = [
+  testAlertResolvesOnDismiss,
+  testConfirmOutcomes,
+  testConfirmIgnoresClicksInsideTheBox,
+  testPromptReturnsTextOrNull,
+  testEnterAccepts,
+  testEmptyInputIsRefusedNotResolved,
+  testPasswordIsNotTrimmed,
+  testFocusIsRestored,
+  testKeyListenerIsReleased,
+];
+
+for (const t of tests) await t();
+
+if (failures) {
+  console.error(`\n${failures} dialog test(s) failed`);
+  process.exit(1);
+}
+console.log("\nall dialog tests passed");

--- a/settings-ui/index.html
+++ b/settings-ui/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>whatRust — Settings</title>
     <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="dialog.css" />
   </head>
   <body>
     <h1>whatRust Settings</h1>
@@ -71,6 +72,7 @@
       <span id="note" class="note"></span>
     </div>
 
+    <script src="dialog.js"></script>
     <script src="hotkey.js"></script>
     <script src="main.js"></script>
   </body>

--- a/settings-ui/lock.html
+++ b/settings-ui/lock.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>whatRust — Locked</title>
     <link rel="stylesheet" href="lock.css" />
+    <link rel="stylesheet" href="dialog.css" />
   </head>
   <body>
     <div class="lock-card">
@@ -16,6 +17,7 @@
       <p id="error" class="error" role="alert"></p>
       <a id="reset" href="#" class="reset">Forgot password? Reset…</a>
     </div>
+    <script src="dialog.js"></script>
     <script src="lock.js"></script>
   </body>
 </html>

--- a/settings-ui/lock.js
+++ b/settings-ui/lock.js
@@ -55,9 +55,10 @@ async function init() {
 
   document.getElementById("reset").addEventListener("click", async (e) => {
     e.preventDefault();
-    const ok = confirm(
-      "Reset whatRust?\n\nThis logs out ALL accounts and removes the app lock. " +
-      "You will need to re-scan the WhatsApp QR code. Your chats stay on your phone."
+    const ok = await Dlg.confirm(
+      "This logs out ALL accounts and removes the app lock. You will need to " +
+      "re-scan the WhatsApp QR code. Your chats stay on your phone.",
+      { title: "Reset whatRust?", okLabel: "Reset", danger: true }
     );
     if (!ok) return;
     try {

--- a/settings-ui/main.js
+++ b/settings-ui/main.js
@@ -68,15 +68,19 @@ function renderAccounts(accounts) {
     renameBtn.className = "secondary";
     renameBtn.textContent = "Rename";
     renameBtn.addEventListener("click", async () => {
-      const next = prompt("Rename account", a.name);
-      if (next && next.trim() && next.trim() !== a.name) {
-        try {
-          await invoke("rename_account", { id: a.id, name: next.trim() });
-        } catch (e) {
-          alert(String(e));
-        }
-        await loadAccounts();
+      const next = await Dlg.prompt("", {
+        title: "Rename account",
+        value: a.name,
+        okLabel: "Rename",
+        requiredMessage: "An account needs a name.",
+      });
+      if (next === null || next === a.name) return;
+      try {
+        await invoke("rename_account", { id: a.id, name: next });
+      } catch (e) {
+        await Dlg.alert(String(e), { title: "Could not rename" });
       }
+      await loadAccounts();
     });
     row.appendChild(renameBtn);
 
@@ -85,11 +89,16 @@ function renderAccounts(accounts) {
     removeBtn.textContent = "Remove";
     removeBtn.disabled = !canRemove;
     removeBtn.addEventListener("click", async () => {
-      if (!confirm(`Remove account "${a.name}"? Its local session will be deleted.`)) return;
+      const ok = await Dlg.confirm(`Its local session will be deleted, and you will need to scan the QR code again to use this number.`, {
+        title: `Remove "${a.name}"?`,
+        okLabel: "Remove",
+        danger: true,
+      });
+      if (!ok) return;
       try {
         await invoke("remove_account", { id: a.id });
       } catch (e) {
-        alert(String(e));
+        await Dlg.alert(String(e), { title: "Could not remove" });
       }
       await loadAccounts();
     });
@@ -127,7 +136,7 @@ async function addAccount() {
       document.getElementById("add_account").disabled = true;
       document.getElementById("new_account_name").disabled = true;
     } else {
-      alert(msg);
+      await Dlg.alert(msg, { title: "Could not add account" });
     }
   }
 }
@@ -188,47 +197,64 @@ function wireLock() {
       document.getElementById("lock_pw1").value = "";
       document.getElementById("lock_pw2").value = "";
       await loadLock();
-    } catch (e) { alert(String(e)); }
+    } catch (e) { await Dlg.alert(String(e), { title: "Could not enable the lock" }); }
   });
 
   document.getElementById("lock_now").addEventListener("click", async () => {
-    try { await invoke("lock_app"); } catch (e) { alert(String(e)); }
+    try { await invoke("lock_app"); } catch (e) { await Dlg.alert(String(e), { title: "Could not lock" }); }
   });
 
   document.getElementById("change_pw").addEventListener("click", async () => {
-    const current = prompt("Current password:");
+    const current = await Dlg.prompt("", {
+      title: "Current password",
+      password: true,
+      okLabel: "Continue",
+      requiredMessage: "Enter your current password.",
+    });
     if (current === null) return;
-    const next = prompt("New password (min 4):");
-    if (!next) return;
+    const next = await Dlg.prompt("At least 4 characters.", {
+      title: "New password",
+      password: true,
+      okLabel: "Change",
+      requiredMessage: "Enter a new password.",
+    });
+    if (next === null) return;
     try {
       await invoke("change_app_lock_password", { current, new: next, confirm: next });
-      alert("Password changed.");
-    } catch (e) { alert(String(e)); }
+      await Dlg.alert("Your app-lock password has been changed.", { title: "Password changed" });
+    } catch (e) { await Dlg.alert(String(e), { title: "Could not change the password" }); }
   });
 
   document.getElementById("disable_lock").addEventListener("click", async () => {
-    const current = prompt("Enter your current password to disable the lock:");
+    const current = await Dlg.prompt("Enter your current password to turn the app lock off.", {
+      title: "Disable app lock",
+      password: true,
+      okLabel: "Disable",
+      danger: true,
+      requiredMessage: "Enter your current password.",
+    });
     if (current === null) return;
     try {
       await invoke("disable_app_lock", { current });
       await loadLock();
-    } catch (e) { alert(String(e)); }
+    } catch (e) { await Dlg.alert(String(e), { title: "Could not disable the lock" }); }
   });
 
   document.getElementById("biometric_enabled").addEventListener("change", async (e) => {
     try {
       await invoke("set_biometric_enabled", { enabled: e.target.checked });
     } catch (err) {
-      alert(String(err));
       e.target.checked = !e.target.checked; // revert on failure
+      await Dlg.alert(String(err), { title: "Could not change biometric unlock" });
     }
     await loadLock();
   });
 
+  const reportLockOptionFailure = (e) => Dlg.alert(String(e), { title: "Could not save" });
   for (const id of ["lock_on_launch", "lock_on_hide"]) {
-    document.getElementById(id).addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
+    document.getElementById(id).addEventListener("change", () => saveLockOptions().catch(reportLockOptionFailure));
   }
-  document.getElementById("idle_min").addEventListener("change", () => saveLockOptions().catch((e) => alert(String(e))));
+  document.getElementById("idle_min").addEventListener("change", () => saveLockOptions().catch(reportLockOptionFailure));
 }
 
 // --- Shortcut recorder ---


### PR DESCRIPTION
## Problem

Five controls in the settings UI do nothing at all on macOS:

| control | call | what happens on macOS |
| --- | --- | --- |
| Accounts → Rename | `prompt()` | returns `null`, nothing drawn |
| Accounts → Remove | `confirm()` | returns `false`, nothing drawn |
| Security → Change password… | `prompt()` | returns `null` |
| Security → Disable… | `prompt()` | returns `null` |
| Lock screen → "Forgot password? Reset…" | `confirm()` | returns `false` |

Every `alert(...)` error path is swallowed the same way, so failures from `add_account`, `lock_app`, `set_biometric_enabled` and the lock options are invisible.

The cause is not in this repo. WKWebView shows a JavaScript dialog only if the host implements the matching `WKUIDelegate` panel method (`runJavaScriptTextInputPanelWithPrompt:`, `runJavaScriptConfirmPanelWithMessage:`, `runJavaScriptAlertPanelWithMessage:`). wry implements none of them: `src/wkwebview/class/wry_web_view_ui_delegate.rs` covers only the open-file panel, media-capture permission, and `createWebViewWithConfiguration`. WebKit's documented behaviour when the delegate omits these is to complete immediately with the default value, without drawing anything and without raising an error.

Windows (WebView2) and Linux (WebKitGTK) answer these calls natively, which is why the same code works everywhere else and the breakage is macOS-only.

## Change

`settings-ui/dialog.js` and `dialog.css`: `alert`, `confirm` and `prompt` built from page elements. Same shape as the natives, but async, so call sites become `await Dlg.confirm(...)` instead of `if (confirm(...))`.

Behaviour:

- Escape, Cancel, or a click on the backdrop dismisses; a click inside the box does not.
- Enter in the text field accepts.
- Tab is trapped inside the dialog, and focus is restored to whatever opened it.
- An empty required field shows an inline error rather than resolving an empty string, so `prompt` cancelling (`null`) stays distinguishable from an empty answer.
- Passwords are passed through untrimmed. `window.prompt` does not trim, and trimming would silently mangle a password with edge whitespace.
- One dialog at a time; the styles stand on their own so both `index.html` and `lock.html` can load them without extending either page's sheet.

Every call site moves over, and the error paths that used `alert()` now name the action that failed ("Could not rename", "Could not disable the lock") instead of showing a bare message.

## Testing

`settings-ui/dialog.test.mjs`: 9 cases, 25 assertions, run against a stubbed DOM in the same zero-dependency style as `bridge.test.mjs` and `comboToAccelerator.test.mjs`. Added as a step in `check.yml`.

The test exists because of the failure mode itself: a regression here is invisible on the Linux and Windows CI runners and surfaces only as a dead button on macOS.

Also verified by hand in a release build on macOS 15 (Apple Silicon): rename, remove, change password, disable lock, and the reset link all work now.

## Alternative considered

`tauri-plugin-dialog` gives native `ask`/`message`, but has no text-input prompt, so rename and the password flows would still need in-page UI. Doing all of them one way keeps the behaviour consistent across the three platforms and adds no dependency.
