### PR TITLE
feat(settings): add a display-size selector for the WhatsApp webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The official WhatsApp Desktop app is built on Electron, which packs an entire Ch
 - **Optional app lock** — password (Argon2id) or biometric (Windows Hello / Touch ID / Linux polkit); locks on launch, on demand, on hide-to-tray, or after idle
 - **System tray** icon with **close-to-tray** and an **unread message badge**
 - **Native OS notifications** for new messages
+- **Display size** — a Smaller / Small / Default / Big page zoom in Settings, so the chat list stops crowding out the conversation on a high-DPI screen
 - **Persistent login** — scan the QR code once, stay signed in across restarts
 - **Voice messages** everywhere, plus **voice & video calls** where the system webview ships WebRTC (Windows and macOS; most Linux distros build WebKitGTK without WebRTC, so calling isn't available on Linux)
 - **Drag and drop files and images** — drop a photo, video, or document straight onto a chat to attach it

--- a/settings-ui/index.html
+++ b/settings-ui/index.html
@@ -25,6 +25,18 @@
     <label class="row"><input type="checkbox" id="start_minimized" /> <span>Start minimized to tray</span></label>
     <label class="row"><input type="checkbox" id="autostart" /> <span>Launch at system startup</span></label>
     <label class="row"><input type="checkbox" id="notifications" /> <span>Native notifications</span></label>
+
+    <label class="field">
+      <span>Display size</span>
+      <select id="zoom">
+        <option value="0.75">Smaller</option>
+        <option value="0.85">Small</option>
+        <option value="1">Default</option>
+        <option value="1.15">Big</option>
+      </select>
+    </label>
+    <p class="field-note">Scales the whole WhatsApp page, and applies as soon as you pick it. A smaller size leaves more room for the conversation next to the chat list, which is usually what you want on a high-DPI display.</p>
+
     <label class="row"><input type="checkbox" id="hotkey_enabled" /> <span>Enable global show/hide shortcut</span></label>
 
     <label class="field">

--- a/settings-ui/main.js
+++ b/settings-ui/main.js
@@ -1,5 +1,15 @@
 const invoke = window.__TAURI__.core.invoke;
 const BOOLS = ["close_to_tray", "start_minimized", "autostart", "notifications", "hotkey_enabled"];
+const ZOOM_DEFAULT = 1;
+
+// settings.json holds a zoom factor, not a preset name, so a stored value need
+// not be one of the four options offered here — it can come from a hand edit or
+// from a build with a different set of presets. Show the closest one.
+function selectNearestZoom(value) {
+  const sel = document.getElementById("zoom");
+  const distance = (o) => Math.abs(parseFloat(o.value) - value);
+  sel.value = [...sel.options].reduce((a, b) => (distance(b) < distance(a) ? b : a)).value;
+}
 
 async function load() {
   const s = await invoke("get_settings");
@@ -8,6 +18,7 @@ async function load() {
     if (el) el.checked = !!s[f];
   }
   document.getElementById("hotkey").value = s.hotkey || "CmdOrCtrl+Shift+W";
+  selectNearestZoom(Number.isFinite(s.zoom) ? s.zoom : ZOOM_DEFAULT);
 }
 
 async function save() {
@@ -18,6 +29,7 @@ async function save() {
   }
   const hk = document.getElementById("hotkey").value.trim();
   s.hotkey = hk || "CmdOrCtrl+Shift+W";
+  s.zoom = parseFloat(document.getElementById("zoom").value) || ZOOM_DEFAULT;
   const note = document.getElementById("note");
   try {
     const warn = await invoke("set_settings", { settings: s });
@@ -143,6 +155,9 @@ window.addEventListener("DOMContentLoaded", () => {
     if (e.key === "Enter") addAccount();
   });
   document.getElementById("record_hotkey").addEventListener("click", toggleRecording);
+  // Zoom saves on change rather than on Save: picking a size you cannot see the
+  // effect of is guesswork, and the webview applies it immediately.
+  document.getElementById("zoom").addEventListener("change", save);
 });
 
 // --- App lock ---

--- a/settings-ui/style.css
+++ b/settings-ui/style.css
@@ -13,9 +13,20 @@ h1 { font-size: 17px; margin: 0 0 16px; }
 .row { display: flex; align-items: center; gap: 10px; padding: 8px 0; cursor: pointer; }
 .row input { width: 16px; height: 16px; accent-color: var(--green); }
 .field { display: flex; flex-direction: column; gap: 6px; margin: 12px 0; }
-.field input {
+.field input, .field select {
   padding: 8px 10px; border: 1px solid #8884; border-radius: 8px;
   background: transparent; color: inherit; font-size: 13px;
+}
+/* A native popup button carries its own fixed control metrics and ignores most
+   of the padding above, so it renders shorter than the text fields beside it.
+   Drop the native appearance and draw the chevron ourselves; the select then
+   uses the same box as every input in this pane. */
+.field select {
+  appearance: none; -webkit-appearance: none;
+  line-height: normal; padding-right: 30px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%238696a0' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
 }
 .actions { display: flex; align-items: center; gap: 12px; margin-top: 18px; }
 button {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -108,6 +108,7 @@ pub fn set_settings(
         return Err("forbidden".into());
     }
     lock::require_unlocked(&app)?;
+    let settings = settings.sanitized();
     crate::settings::save(&app, &settings).map_err(|e| e.to_string())?;
     Ok(crate::settings::apply(&app, &settings))
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -9,6 +9,8 @@ pub struct Settings {
     pub hotkey_enabled: bool,
     pub hotkey: String,
     pub notifications: bool,
+    /// Display zoom for the WhatsApp webview, 1.0 = the site's own sizing.
+    pub zoom: f64,
 }
 
 impl Default for Settings {
@@ -20,7 +22,33 @@ impl Default for Settings {
             hotkey_enabled: true,
             hotkey: "CmdOrCtrl+Shift+W".to_string(),
             notifications: true,
+            zoom: 1.0,
         }
+    }
+}
+
+/// Zoom bounds. The settings UI only offers four presets inside this range; the
+/// clamp exists so a hand-edited settings.json cannot leave the app at a zoom
+/// level from which the settings window is unreadable.
+pub const ZOOM_MIN: f64 = 0.5;
+pub const ZOOM_MAX: f64 = 2.0;
+
+/// Bring a zoom factor into range. A non-finite value (a `null` or a string in
+/// the JSON deserialises to the default, but arithmetic in an older build could
+/// still have written a NaN) falls back to 1.0 rather than to a bound.
+pub fn sanitize_zoom(zoom: f64) -> f64 {
+    if zoom.is_finite() {
+        zoom.clamp(ZOOM_MIN, ZOOM_MAX)
+    } else {
+        1.0
+    }
+}
+
+impl Settings {
+    /// Repair values an older or hand-edited settings.json can carry.
+    pub fn sanitized(mut self) -> Self {
+        self.zoom = sanitize_zoom(self.zoom);
+        self
     }
 }
 
@@ -37,7 +65,8 @@ pub fn load(app: &AppHandle) -> Settings {
     settings_path(app)
         .ok()
         .and_then(|p| std::fs::read_to_string(p).ok())
-        .and_then(|s| serde_json::from_str(&s).ok())
+        .and_then(|s| serde_json::from_str::<Settings>(&s).ok())
+        .map(Settings::sanitized)
         .unwrap_or_default()
 }
 
@@ -52,6 +81,10 @@ pub fn save(app: &AppHandle, s: &Settings) -> tauri::Result<()> {
 /// shortcut registration error as `Some(msg)` if registering failed; `None` if it
 /// registered successfully, or the shortcut is disabled/empty, or on non-desktop.
 pub fn apply(app: &AppHandle, s: &Settings) -> Option<String> {
+    // Zoom is a webview property, so it applies on every platform and takes
+    // effect on the open account windows without a reload.
+    crate::window::apply_zoom_all(app, s.zoom);
+
     #[cfg(desktop)]
     {
         use tauri_plugin_autostart::ManagerExt;
@@ -82,7 +115,7 @@ pub fn apply(app: &AppHandle, s: &Settings) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::Settings;
+    use super::{sanitize_zoom, Settings, ZOOM_MAX, ZOOM_MIN};
 
     #[test]
     fn defaults_are_sane() {
@@ -91,6 +124,36 @@ mod tests {
         assert!(s.notifications);
         assert_eq!(s.hotkey, "CmdOrCtrl+Shift+W");
         assert!(!s.autostart);
+        assert_eq!(s.zoom, 1.0);
+    }
+
+    #[test]
+    fn zoom_presets_survive_sanitizing() {
+        for z in [0.75, 0.85, 1.0, 1.15] {
+            assert_eq!(sanitize_zoom(z), z);
+        }
+    }
+
+    #[test]
+    fn out_of_range_zoom_is_clamped() {
+        assert_eq!(sanitize_zoom(0.01), ZOOM_MIN);
+        assert_eq!(sanitize_zoom(9.0), ZOOM_MAX);
+        assert_eq!(sanitize_zoom(-1.0), ZOOM_MIN);
+    }
+
+    #[test]
+    fn non_finite_zoom_falls_back_to_unscaled() {
+        assert_eq!(sanitize_zoom(f64::NAN), 1.0);
+        assert_eq!(sanitize_zoom(f64::INFINITY), 1.0);
+    }
+
+    #[test]
+    fn zoom_from_json_is_sanitized() {
+        let s: Settings = serde_json::from_str(r#"{"zoom": 12}"#).unwrap();
+        assert_eq!(s.sanitized().zoom, ZOOM_MAX);
+        // Absent in a settings.json written by an older build.
+        let s: Settings = serde_json::from_str(r#"{"autostart": true}"#).unwrap();
+        assert_eq!(s.sanitized().zoom, 1.0);
     }
 
     #[test]

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -133,10 +133,33 @@ pub fn open_account_window(
         }
     });
 
+    apply_zoom(&win, crate::settings::load(app).zoom);
     register_focus_listener(app, &win);
     register_drop_handler(&win);
     enable_webview_media(&win);
     Ok(win)
+}
+
+/// Set the display zoom on one account webview.
+///
+/// This is a page zoom rather than a font-size override, because WhatsApp Web
+/// sizes nearly everything in px: scaling the page is what moves the chat list
+/// and the conversation pane together. Zooming out is also what buys back
+/// horizontal space on a high-DPI display, where the chat list otherwise takes a
+/// disproportionate share of the window.
+fn apply_zoom(win: &WebviewWindow, zoom: f64) {
+    // Unsupported below macOS 11; there the window keeps the site's own sizing.
+    let _ = win.set_zoom(crate::settings::sanitize_zoom(zoom));
+}
+
+/// Re-apply the display zoom to every open account window, so changing the
+/// setting takes effect immediately instead of at the next launch.
+pub fn apply_zoom_all(app: &AppHandle, zoom: f64) {
+    for a in accounts::load(app).accounts {
+        if let Some(w) = app.get_webview_window(&accounts::window_label(&a.id)) {
+            apply_zoom(&w, zoom);
+        }
+    }
 }
 
 /// Largest single dropped file we will inline-inject into the page. The page must


### PR DESCRIPTION
## Problem

WhatsApp Web sizes its layout in px and has no scaling control of its own, so the chat list occupies the same width whatever the display. On a large high-DPI screen that leaves the conversation pane cramped while the chat list takes a disproportionate share of the window, and nothing inside whatRust could change it.

## Change

A **Display size** selector under Settings → Preferences: Smaller (0.75), Small (0.85), Default (1.0), Big (1.15).

- Stored as a `zoom` factor in `settings.json`, defaulting to 1.0, so existing files keep today's behaviour with no migration.
- Applied through the webview's own page zoom (`WebviewWindow::set_zoom`), not a font-size override. A font-size override moves almost nothing on a page that sizes in px; scaling the page is what moves the chat list and the conversation together.
- Set when an account window is built, and re-applied to every open account window when the setting changes, so a new size takes effect without a restart.
- Saves on `change` rather than waiting for Save, since a size you have not seen is a guess.

Robustness:

- `zoom` is clamped to 0.5–2.0 on load and on save, and a non-finite value falls back to 1.0, so a hand-edited `settings.json` cannot leave the app at a size you cannot read your way back out of.
- The settings UI shows the option nearest the stored value rather than assuming it is one of the four presets.
- Page zoom needs macOS 11 or later (Tauri's documented constraint); below that the call is a no-op and the window keeps the site's own sizing.

The select gets `appearance: none` plus an inline-SVG chevron: a native popup button carries fixed control metrics and ignores most of the `.field` padding, so it rendered visibly shorter than the text inputs beside it.

## Testing

- 4 new unit tests in `settings.rs` covering the presets, clamping, non-finite input, and an older `settings.json` with no `zoom` key. Full suite: 70 pass. `cargo fmt --check` clean.
- Built a release bundle and ran it on macOS 15 (Apple Silicon) against a live account: switching size applies immediately across open account windows and survives a restart.
- Not exercised on Linux or Windows beyond CI's compile; `set_zoom` is Tauri's own cross-platform API and there is no platform-specific code in this change.
