### PR TITLE
Fix Windows notifications and multi-account startup

### DIFF
--- a/settings-ui/index.html
+++ b/settings-ui/index.html
@@ -12,11 +12,17 @@
 
     <h2>Accounts</h2>
     <div id="accounts-list"></div>
+    <label class="field">
+      <span>Default account on startup</span>
+      <select id="startup_account" aria-describedby="startup-note"></select>
+    </label>
+    <p id="startup-note" class="field-note">This account opens first. Other accounts stay connected in the background.</p>
     <div class="add-row">
       <input type="text" id="new_account_name" placeholder="New account name" />
       <button id="add_account">+ Add account</button>
     </div>
     <p id="macos-note" class="macos-note" hidden>Multiple accounts require macOS 14 or newer.</p>
+    <p id="accounts-note" class="note" role="status" aria-live="polite"></p>
 
     <hr class="divider" />
 

--- a/settings-ui/main.js
+++ b/settings-ui/main.js
@@ -46,11 +46,35 @@ async function save() {
 }
 
 // --- Accounts ---
+let accountsBusy = false;
+
+async function accountAction(action) {
+  if (accountsBusy) return;
+  accountsBusy = true;
+  document.querySelectorAll('#accounts-list button, .add-row input, .add-row button, #startup_account')
+    .forEach(el => { el.disabled = true; });
+  const note = document.getElementById('accounts-note');
+  note.textContent = 'Working…';
+  try {
+    await action();
+    note.textContent = '';
+  } catch (error) {
+    note.textContent = String(error);
+  } finally {
+    accountsBusy = false;
+    document.getElementById('new_account_name').disabled = false;
+    document.getElementById('add_account').disabled = false;
+    document.getElementById('startup_account').disabled = false;
+    await loadAccounts();
+  }
+}
 
 function renderAccounts(accounts) {
   const list = document.getElementById("accounts-list");
   list.textContent = "";
   const canRemove = accounts.length > 1;
+  const startup = document.getElementById('startup_account');
+  startup.textContent = '';
 
   for (const a of accounts) {
     const row = document.createElement("div");
@@ -60,6 +84,11 @@ function renderAccounts(accounts) {
     name.className = "acct-name";
     name.textContent = a.name;
     row.appendChild(name);
+    const option = document.createElement('option');
+    option.value = a.id;
+    option.textContent = a.name;
+    option.selected = a.is_default;
+    startup.appendChild(option);
 
     if (a.unread > 0) {
       const badge = document.createElement("span");
@@ -72,7 +101,7 @@ function renderAccounts(accounts) {
     openBtn.className = "secondary";
     openBtn.textContent = "Open";
     openBtn.addEventListener("click", async () => {
-      await invoke("open_account", { id: a.id });
+      await accountAction(() => invoke("open_account", { id: a.id }));
     });
     row.appendChild(openBtn);
 
@@ -87,12 +116,7 @@ function renderAccounts(accounts) {
         requiredMessage: "An account needs a name.",
       });
       if (next === null || next === a.name) return;
-      try {
-        await invoke("rename_account", { id: a.id, name: next });
-      } catch (e) {
-        await Dlg.alert(String(e), { title: "Could not rename" });
-      }
-      await loadAccounts();
+      await accountAction(() => invoke("rename_account", { id: a.id, name: next }));
     });
     row.appendChild(renameBtn);
 
@@ -107,12 +131,7 @@ function renderAccounts(accounts) {
         danger: true,
       });
       if (!ok) return;
-      try {
-        await invoke("remove_account", { id: a.id });
-      } catch (e) {
-        await Dlg.alert(String(e), { title: "Could not remove" });
-      }
-      await loadAccounts();
+      await accountAction(() => invoke("remove_account", { id: a.id }));
     });
     row.appendChild(removeBtn);
 
@@ -125,32 +144,18 @@ async function loadAccounts() {
     const accounts = await invoke("list_accounts");
     renderAccounts(accounts);
   } catch (e) {
-    // ignore — listing failed
+    document.getElementById('accounts-note').textContent = 'Could not load accounts: ' + String(e);
   }
 }
 
 async function addAccount() {
   const input = document.getElementById("new_account_name");
   const name = input.value.trim();
-  if (!name) return;
-  try {
+  if (!name || accountsBusy) return;
+  await accountAction(async () => {
     await invoke("add_account", { name });
     input.value = "";
-    await loadAccounts();
-  } catch (e) {
-    const msg = String(e);
-    // Only the macOS < 14 case is permanent — disable Add and surface the note.
-    // Other failures (disk write, window build) are transient: report and let the user retry.
-    if (msg.includes("macOS 14")) {
-      const note = document.getElementById("macos-note");
-      note.textContent = msg;
-      note.hidden = false;
-      document.getElementById("add_account").disabled = true;
-      document.getElementById("new_account_name").disabled = true;
-    } else {
-      await Dlg.alert(msg, { title: "Could not add account" });
-    }
-  }
+  });
 }
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -160,6 +165,10 @@ window.addEventListener("DOMContentLoaded", () => {
   wireLock();
   document.getElementById("save").addEventListener("click", save);
   document.getElementById("add_account").addEventListener("click", addAccount);
+  document.getElementById('startup_account').addEventListener('change', event => {
+    const id = event.target.value;
+    accountAction(() => invoke('set_default_account', { id }));
+  });
   document.getElementById("new_account_name").addEventListener("keydown", (e) => {
     if (e.key === "Enter") addAccount();
   });

--- a/settings-ui/style.css
+++ b/settings-ui/style.css
@@ -1,7 +1,15 @@
 :root {
   color-scheme: light dark;
   --green: #25d366;
+  --option-bg: #fff;
+  --option-fg: #171717;
 }
+@media (prefers-color-scheme: dark) {
+  :root { --option-bg: #202020; --option-fg: #f5f5f5; }
+}
+/* WebView2's native popup can use a light surface even when select inherits
+   white text. Specify BOTH colors so every option stays readable without hover. */
+.field select option { background-color: var(--option-bg); color: var(--option-fg); }
 * { box-sizing: border-box; }
 body {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
@@ -44,10 +52,10 @@ h2 { font-size: 14px; margin: 0 0 10px; font-weight: 600; }
 .divider { border: 0; border-top: 1px solid #8883; margin: 18px 0; }
 #accounts-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
 .account-row {
-  display: flex; align-items: center; gap: 8px;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
   padding: 8px 10px; border: 1px solid #8884; border-radius: 8px;
 }
-.account-row .acct-name { flex: 1 1 auto; font-size: 13px; }
+.account-row .acct-name { flex: 1 1 100%; min-width: 0; overflow-wrap: anywhere; font-size: 13px; }
 .account-row .acct-unread {
   min-width: 20px; height: 20px; padding: 0 6px; border-radius: 10px;
   background: var(--green); color: #042f1a; font-size: 11px; font-weight: 700;

--- a/src-tauri/capabilities/lock.json
+++ b/src-tauri/capabilities/lock.json
@@ -3,5 +3,5 @@
   "identifier": "lock-local",
   "description": "IPC for the app-lock screen. core:default for invoke; no remote, no account/notification permissions. Per-command authorization is enforced in Rust (is_lock_window).",
   "windows": ["lock"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "allow-lock-commands"]
 }

--- a/src-tauri/capabilities/main-remote.json
+++ b/src-tauri/capabilities/main-remote.json
@@ -6,5 +6,5 @@
   "remote": {
     "urls": ["https://web.whatsapp.com/*"]
   },
-  "permissions": ["notification:default"]
+  "permissions": ["allow-whatsapp-bridge"]
 }

--- a/src-tauri/capabilities/settings.json
+++ b/src-tauri/capabilities/settings.json
@@ -3,5 +3,5 @@
   "identifier": "settings-local",
   "description": "Local IPC for the settings window.",
   "windows": ["settings"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "allow-settings-commands"]
 }

--- a/src-tauri/permissions/app.toml
+++ b/src-tauri/permissions/app.toml
@@ -1,0 +1,22 @@
+# Custom commands need their own ACL entries; notification:default only grants
+# plugin:notification commands. Defining this manifest also opts LOCAL windows
+# into ACL checks, so preserve their separate settings and unlock permissions.
+[[permission]]
+identifier = "allow-whatsapp-bridge"
+description = "Forward notifications, unread titles and diagnostics from WhatsApp account windows."
+commands.allow = ["notify", "set_unread", "dlog"]
+
+[[permission]]
+identifier = "allow-settings-commands"
+description = "Manage settings and accounts from the bundled settings window."
+commands.allow = [
+  "get_settings", "set_settings", "open_settings", "list_accounts",
+  "add_account", "remove_account", "rename_account", "open_account", "set_default_account",
+  "get_lock_status", "set_app_lock_password", "change_app_lock_password",
+  "disable_app_lock", "set_app_lock_options", "set_biometric_enabled", "lock_app"
+]
+
+[[permission]]
+identifier = "allow-lock-commands"
+description = "Read lock status and unlock or reset from the bundled lock screen."
+commands.allow = ["get_lock_status", "unlock_password", "unlock_biometric", "reset_app_lock"]

--- a/src-tauri/resources/bridge.js
+++ b/src-tauri/resources/bridge.js
@@ -5,7 +5,12 @@
   function invoke(cmd, args) {
     var t = window.__TAURI__;
     if (t && t.core && typeof t.core.invoke === "function") {
-      return t.core.invoke(cmd, args).catch(function () {});
+      return t.core.invoke(cmd, args).catch(function () {
+        // Do not log args or error payloads: they can contain message content.
+        // In particular, an ACL rejection must not silently disable both
+        // notifications and the unread tray indicator.
+        console.error("whatRust bridge: IPC failed for " + cmd);
+      });
     }
     return Promise.resolve();
   }

--- a/src-tauri/resources/notifications.test.mjs
+++ b/src-tauri/resources/notifications.test.mjs
@@ -1,0 +1,71 @@
+// Run with: node --test src-tauri/resources/notifications.test.mjs
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { test } from 'node:test';
+
+const source = readFileSync(new URL('./bridge.js', import.meta.url), 'utf8');
+
+function harness({ reject = false } = {}) {
+  const calls = [], errors = [], intervals = [];
+  const document = {
+    title: '(3) WhatsApp', readyState: 'complete',
+    querySelector: () => null, querySelectorAll: () => [],
+    addEventListener() {},
+  };
+  const window = {
+    location: { origin: 'https://web.whatsapp.com' }, addEventListener() {},
+    ServiceWorkerRegistration: class {
+      showNotification() {}
+      getNotifications() {}
+    },
+    __TAURI__: { core: { invoke(cmd, args) {
+      calls.push({ cmd, args });
+      return reject ? Promise.reject('private message payload') : Promise.resolve();
+    } } },
+  };
+  runInNewContext(source, {
+    window, document, navigator: {},
+    console: { error: message => errors.push(message), log() {} },
+    MutationObserver: class { observe() {} },
+    setInterval: callback => { intervals.push(callback); return 0; },
+    setTimeout: () => 0, clearTimeout() {},
+  });
+  return { window, document, calls, errors, intervals };
+}
+
+test('page and service-worker registration notifications reach the custom Rust command', async () => {
+  const { window, calls } = harness();
+  new window.Notification('test A', { body: 'body A' });
+  await new window.ServiceWorkerRegistration().showNotification('test B', { body: 'body B' });
+  const notifications = calls.filter(c => c.cmd === 'notify');
+  assert.equal(notifications.length, 2);
+  assert.equal(notifications[0].args.title, 'test A');
+  assert.equal(notifications[1].args.body, 'body B');
+});
+
+test('the two notification paths do not duplicate the same alert', async () => {
+  const { window, calls } = harness();
+  new window.Notification('same', { body: 'message' });
+  await new window.ServiceWorkerRegistration().showNotification('same', { body: 'message' });
+  assert.equal(calls.filter(c => c.cmd === 'notify').length, 1);
+});
+
+test('unread initialization, changes and clearing reach Rust without repeating unchanged titles', () => {
+  const { document, calls, intervals } = harness();
+  const poll = intervals[0];
+  poll();
+  document.title = '(4) WhatsApp'; poll();
+  document.title = 'WhatsApp'; poll(); poll();
+  assert.deepEqual(calls.filter(c => c.cmd === 'set_unread').map(c => c.args.title),
+    ['(3) WhatsApp', '(4) WhatsApp', 'WhatsApp']);
+});
+
+test('IPC rejection is visible without logging private notification content', async () => {
+  const { window, errors } = harness({ reject: true });
+  new window.Notification('private title', { body: 'private body' });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.ok(errors.includes('whatRust bridge: IPC failed for notify'));
+  assert.ok(errors.includes('whatRust bridge: IPC failed for set_unread'));
+  assert.ok(errors.every(message => !message.includes('private')));
+});

--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -8,6 +8,8 @@ use tauri::{AppHandle, Manager};
 pub type UnreadMap = Mutex<HashMap<String, u32>>;
 /// Window label of the last-focused account window (e.g. `wa-default`). Managed app state.
 pub type ActiveAccount = Mutex<String>;
+/// Serialize account mutations now that window-opening commands run off the UI thread.
+pub static MUTATION: Mutex<()> = Mutex::new(());
 
 /// A single WhatsApp account.
 ///
@@ -32,6 +34,8 @@ pub struct Account {
 pub struct AccountsFile {
     pub accounts: Vec<Account>,
     pub next_seq: u32,
+    /// Preferred startup account; independent of the historical `default` profile id.
+    pub startup_account: Option<String>,
 }
 
 impl Default for AccountsFile {
@@ -44,6 +48,7 @@ impl Default for AccountsFile {
                 store_uuid: None,
             }],
             next_seq: 1,
+            startup_account: None,
         }
     }
 }
@@ -82,7 +87,27 @@ pub fn remove(f: &mut AccountsFile, id: &str) -> Result<Account, String> {
     let Some(pos) = f.accounts.iter().position(|a| a.id == id) else {
         return Err(format!("unknown account: {id}"));
     };
-    Ok(f.accounts.remove(pos))
+    let removed = f.accounts.remove(pos);
+    if f.startup_account.as_deref() == Some(id) {
+        f.startup_account = None;
+    }
+    Ok(removed)
+}
+
+/// Older files and a removed preference fall back to the first account in UI order.
+pub fn startup_account(f: &AccountsFile) -> Option<&Account> {
+    f.startup_account
+        .as_deref()
+        .and_then(|id| f.accounts.iter().find(|a| a.id == id))
+        .or_else(|| f.accounts.iter().min_by_key(|a| a.order))
+}
+
+pub fn set_startup_account(f: &mut AccountsFile, id: &str) -> Result<(), String> {
+    if !f.accounts.iter().any(|a| a.id == id) {
+        return Err(format!("unknown account: {id}"));
+    }
+    f.startup_account = Some(id.to_owned());
+    Ok(())
 }
 
 /// Rename an account by id. Errors if the id is unknown.
@@ -206,6 +231,53 @@ pub fn gen_store_uuid() -> [u8; 16] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn startup_preference_survives_roundtrip_without_changing_profile_identity() {
+        let mut f = AccountsFile::default();
+        let second = add(&mut f, "Work");
+        set_startup_account(&mut f, &second.id).unwrap();
+        let restored: AccountsFile =
+            serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap();
+        assert_eq!(startup_account(&restored), Some(&second));
+        assert_eq!(restored.accounts[0].id, "default");
+        assert_eq!(restored.accounts[0].store_uuid, None);
+    }
+
+    #[test]
+    fn missing_or_stale_startup_preference_uses_ui_order() {
+        let mut f = AccountsFile::default();
+        add(&mut f, "Work");
+        f.accounts.reverse();
+        assert_eq!(startup_account(&f).unwrap().id, "default");
+        f.startup_account = Some("removed-id".into());
+        assert_eq!(startup_account(&f).unwrap().id, "default");
+    }
+
+    #[test]
+    fn removing_preferred_account_selects_remaining_account() {
+        let mut f = AccountsFile::default();
+        let second = add(&mut f, "Work");
+        set_startup_account(&mut f, &second.id).unwrap();
+        remove(&mut f, &second.id).unwrap();
+        assert_eq!(startup_account(&f).unwrap().id, "default");
+        assert_eq!(f.startup_account, None);
+    }
+
+    #[test]
+    fn startup_selection_rejects_unknown_id_without_mutating_state() {
+        let mut f = AccountsFile::default();
+        let before = f.clone();
+        assert!(set_startup_account(&mut f, "missing").is_err());
+        assert_eq!(f, before);
+    }
+
+    #[test]
+    fn no_startup_account_when_list_is_empty() {
+        let mut f = AccountsFile::default();
+        f.accounts.clear();
+        assert!(startup_account(&f).is_none());
+    }
 
     #[test]
     fn default_file_has_single_default_account() {

--- a/src-tauri/src/aumid.rs
+++ b/src-tauri/src/aumid.rs
@@ -27,7 +27,6 @@ use tauri::AppHandle;
 pub fn register(app: &AppHandle) {
     #[cfg(windows)]
     {
-        use tauri::Manager;
         let config = app.config();
         let aumid = &config.identifier;
         let display = config.product_name.as_deref().unwrap_or("whatRust");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -134,6 +134,7 @@ pub struct AccountView {
     pub order: u32,
     pub unread: u32,
     pub open: bool,
+    pub is_default: bool,
 }
 
 fn account_views(app: &tauri::AppHandle) -> Vec<AccountView> {
@@ -151,6 +152,7 @@ fn account_views(app: &tauri::AppHandle) -> Vec<AccountView> {
             open: app
                 .get_webview_window(&accounts::window_label(&a.id))
                 .is_some(),
+            is_default: accounts::startup_account(&f).is_some_and(|selected| selected.id == a.id),
         })
         .collect();
     views.sort_by_key(|v| v.order);
@@ -170,7 +172,7 @@ pub fn list_accounts(
 }
 
 #[tauri::command]
-pub fn add_account(
+pub async fn add_account(
     window: tauri::Window,
     app: tauri::AppHandle,
     name: String,
@@ -187,11 +189,24 @@ pub fn add_account(
         return Err("account name cannot be empty".into());
     }
 
+    // WebView2 construction must not run inside a synchronous IPC callback.
+    // Do not move this command back onto the UI thread (wry issue #583).
+    let _mutation = accounts::MUTATION
+        .lock()
+        .map_err(|_| "account operation failed")?;
     let mut f = accounts::load(&app);
     let acct = accounts::add(&mut f, name);
     accounts::save(&app, &f).map_err(|e| e.to_string())?;
 
-    crate::window::open_account_window(&app, &acct, false).map_err(|e| e.to_string())?;
+    if let Err(error) = crate::window::open_account_window(&app, &acct, true) {
+        // Keep the allocated sequence, but do not leave a phantom account after
+        // a failed window build. A retry must allocate a fresh profile id.
+        f.accounts.retain(|a| a.id != acct.id);
+        accounts::save(&app, &f)
+            .map_err(|rollback| format!("{error}; could not roll back account: {rollback}"))?;
+        return Err(error.to_string());
+    }
+    crate::window::show_account(&app, &accounts::window_label(&acct.id));
     crate::tray::rebuild_menu(&app);
 
     Ok(AccountView {
@@ -200,11 +215,12 @@ pub fn add_account(
         order: acct.order,
         unread: 0,
         open: true,
+        is_default: false,
     })
 }
 
 #[tauri::command]
-pub fn remove_account(
+pub async fn remove_account(
     window: tauri::Window,
     app: tauri::AppHandle,
     id: String,
@@ -214,6 +230,9 @@ pub fn remove_account(
     }
     lock::require_unlocked(&app)?;
 
+    let _mutation = accounts::MUTATION
+        .lock()
+        .map_err(|_| "account operation failed")?;
     let mut f = accounts::load(&app);
     let removed = accounts::remove(&mut f, &id)?;
     accounts::save(&app, &f).map_err(|e| e.to_string())?;
@@ -242,7 +261,7 @@ pub fn remove_account(
 }
 
 #[tauri::command]
-pub fn rename_account(
+pub async fn rename_account(
     window: tauri::Window,
     app: tauri::AppHandle,
     id: String,
@@ -257,6 +276,9 @@ pub fn rename_account(
         return Err("account name cannot be empty".into());
     }
 
+    let _mutation = accounts::MUTATION
+        .lock()
+        .map_err(|_| "account operation failed")?;
     let mut f = accounts::load(&app);
     accounts::rename(&mut f, &id, name)?;
     accounts::save(&app, &f).map_err(|e| e.to_string())?;
@@ -269,7 +291,7 @@ pub fn rename_account(
 }
 
 #[tauri::command]
-pub fn open_account(
+pub async fn open_account(
     window: tauri::Window,
     app: tauri::AppHandle,
     id: String,
@@ -278,6 +300,9 @@ pub fn open_account(
         return Err("forbidden".into());
     }
     lock::require_unlocked(&app)?;
+    let _mutation = accounts::MUTATION
+        .lock()
+        .map_err(|_| "account operation failed")?;
     let f = accounts::load(&app);
     let Some(acct) = f.accounts.iter().find(|a| a.id == id) else {
         return Err(format!("unknown account: {id}"));
@@ -287,7 +312,7 @@ pub fn open_account(
         .get_webview_window(&accounts::window_label(&acct.id))
         .is_none()
     {
-        crate::window::open_account_window(&app, acct, false).map_err(|e| e.to_string())?;
+        crate::window::open_account_window(&app, acct, true).map_err(|e| e.to_string())?;
     }
     crate::window::show_account(&app, &accounts::window_label(&acct.id));
     // Track as the active account.
@@ -295,6 +320,24 @@ pub fn open_account(
         *active.lock().unwrap() = accounts::window_label(&acct.id);
     }
     Ok(())
+}
+
+#[tauri::command]
+pub async fn set_default_account(
+    window: tauri::Window,
+    app: tauri::AppHandle,
+    id: String,
+) -> Result<(), String> {
+    if is_remote(&window) {
+        return Err("forbidden".into());
+    }
+    lock::require_unlocked(&app)?;
+    let _mutation = accounts::MUTATION
+        .lock()
+        .map_err(|_| "account operation failed")?;
+    let mut f = accounts::load(&app);
+    accounts::set_startup_account(&mut f, &id)?;
+    accounts::save(&app, &f).map_err(|e| e.to_string())
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,27 +35,34 @@ pub fn run() {
     // single-instance MUST be registered first.
     #[cfg(desktop)]
     {
-        let mut single_instance = tauri_plugin_single_instance::Builder::<tauri::Wry>::new()
-            .callback(|app, args, _cwd| {
+        let single_instance = tauri_plugin_single_instance::Builder::<tauri::Wry>::new().callback(
+            |app, args, _cwd| {
                 // `whatrust --toggle` (bind it to an OS keyboard shortcut — the reliable
                 // global-hotkey path on Wayland, where in-process X11 grabs don't fire)
                 // toggles the active window. Otherwise a 2nd launch raises it, except an
                 // autostart relaunch carrying --minimized (stay hidden in the tray).
                 // Both toggle_active and show_main defer to the lock screen when locked,
                 // so neither can bypass the app lock.
-                if args.iter().any(|a| a == "--toggle") {
+                if args.iter().any(|a| a == "--settings") {
+                    window::open_settings_window(app);
+                } else if args.iter().any(|a| a == "--toggle") {
                     window::toggle_active(app);
                 } else if !args.iter().any(|a| a == "--minimized") {
                     window::show_main(app);
                 }
-            });
+            },
+        );
 
         // Flatpak only permits a sandbox to own D-Bus names under its exported
         // application ID. Native packages keep using the stable Tauri identifier.
         #[cfg(target_os = "linux")]
-        if let Some(id) = settings::flatpak_id() {
-            single_instance = single_instance.dbus_id(id);
-        }
+        let single_instance = {
+            let mut single_instance = single_instance;
+            if let Some(id) = settings::flatpak_id() {
+                single_instance = single_instance.dbus_id(id);
+            }
+            single_instance
+        };
 
         builder = builder.plugin(single_instance.build());
     }
@@ -107,6 +114,7 @@ pub fn run() {
             commands::remove_account,
             commands::rename_account,
             commands::open_account,
+            commands::set_default_account,
             commands::get_lock_status,
             commands::set_app_lock_password,
             commands::change_app_lock_password,
@@ -137,6 +145,7 @@ pub fn run() {
 
             // Load accounts (seeds a single `default` on first run / corrupt file).
             let mut f = accounts::load(handle);
+            dlog::log("startup: account configuration loaded");
 
             // Backfill a persisted store_uuid for any non-default account missing one
             // (older state predating multi-account). Save only if something changed.
@@ -157,18 +166,42 @@ pub fn run() {
             handle.manage(lock::LockState::new(!lock_on_launch));
             let open_hidden = start_hidden || lock_on_launch;
 
-            // Open every account window so each one receives messages/notifications.
-            for a in &f.accounts {
-                window::open_account_window(handle, a, open_hidden)?;
+            let startup_label =
+                accounts::startup_account(&f).map(|account| accounts::window_label(&account.id));
+            if let Some(label) = &startup_label {
+                *handle.state::<accounts::ActiveAccount>().lock().unwrap() = label.clone();
             }
 
+            // Build windows while Tauri is still on its UI thread. On Windows a
+            // WebView2 controller is created lazily for a hidden window, so the
+            // preferred account must be the one made visible here. This keeps
+            // every other account connected in the background and guarantees the
+            // selected startup account is the first usable window.
+            for account in &f.accounts {
+                let is_startup = startup_label
+                    .as_deref()
+                    .is_some_and(|label| label == accounts::window_label(&account.id));
+                window::open_account_window(handle, account, open_hidden || !is_startup)?;
+            }
+            dlog::log("startup: account windows built");
             tray::setup(handle)?;
-            tray::rebuild_menu(handle);
-            let _ = settings::apply(handle, &s);
-
-            if lock_on_launch && !start_hidden {
-                lock::show_lock_window(handle);
-            }
+            // Let setup return before accessing tray/window APIs again. This
+            // avoids waiting on the Windows UI loop while it is being created.
+            let startup_handle = handle.clone();
+            let open_settings = !start_hidden && args.iter().any(|a| a == "--settings");
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                let ui_handle = startup_handle.clone();
+                let _ = startup_handle.run_on_main_thread(move || {
+                    tray::rebuild_menu(&ui_handle);
+                    let _ = settings::apply(&ui_handle, &s);
+                    if lock_on_launch && !start_hidden {
+                        lock::show_lock_window(&ui_handle);
+                    } else if open_settings {
+                        window::open_settings_window(&ui_handle);
+                    }
+                });
+            });
 
             // Idle auto-lock watcher. Always running; no-op unless the lock is active
             // with idle_secs > 0 and the app is currently unlocked.

--- a/src-tauri/src/lock.rs
+++ b/src-tauri/src/lock.rs
@@ -99,6 +99,17 @@ pub fn unlock(app: &AppHandle) {
 /// capture of the lock screen; `prevent_close` while locked stops the X from
 /// relaunching into an unlocked state.
 pub fn show_lock_window(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        static CREATE: Mutex<()> = Mutex::new(());
+        let _guard = CREATE.lock().unwrap_or_else(|e| e.into_inner());
+        if !is_unlocked(&app) {
+            show_lock_window_inner(&app);
+        }
+    });
+}
+
+fn show_lock_window_inner(app: &AppHandle) {
     if let Some(w) = app.get_webview_window("lock") {
         let _ = w.show();
         let _ = w.set_focus();
@@ -116,6 +127,12 @@ pub fn show_lock_window(app: &AppHandle) {
         .build();
 
     if let Ok(win) = built {
+        // Unlock can race a queued window creation; never leave a stale lock
+        // screen on top after authentication has already succeeded.
+        if is_unlocked(app) {
+            let _ = win.destroy();
+            return;
+        }
         let app_handle = app.clone();
         win.on_window_event(move |event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -157,11 +157,20 @@ pub fn apply(app: &AppHandle, s: &Settings) -> Option<String> {
         if !flatpak_autostart_handled {
             use tauri_plugin_autostart::ManagerExt;
             let autostart = app.autolaunch();
-            let result = if s.autostart {
-                autostart.enable()
-            } else {
-                autostart.disable()
-            };
+            let result =
+                if s.autostart {
+                    autostart.enable()
+                } else {
+                    // Windows reports NotFound when deleting an absent Run value.
+                    // Saving "off" when already off is a successful no-op.
+                    autostart.is_enabled().and_then(|enabled| {
+                        if enabled {
+                            autostart.disable()
+                        } else {
+                            Ok(())
+                        }
+                    })
+                };
             if let Err(e) = result {
                 warnings.push(format!("autostart could not be updated: {e}"));
             }

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -115,6 +115,7 @@ pub fn open_account_window(
 
     let builder = apply_isolation(builder, account, app);
     let win = builder.build()?;
+    crate::dlog::log("account window: WebView created");
 
     // Close-to-tray (reads the live setting so the toggle takes effect without a restart).
     let app_handle = app.clone();
@@ -973,6 +974,10 @@ fn enable_media_windows(webview: tauri::webview::PlatformWebview) {
 
 /// Show + unminimize + focus an account window by its `wa-<id>` label.
 pub fn show_account(app: &AppHandle, label: &str) {
+    if !crate::lock::is_unlocked(app) {
+        crate::lock::show_lock_window(app);
+        return;
+    }
     if let Some(w) = app.get_webview_window(label) {
         let _ = w.show();
         let _ = w.unminimize();
@@ -1063,16 +1068,41 @@ pub fn toggle_active(app: &AppHandle) {
 
 /// Opens (or focuses) the local settings window.
 pub fn open_settings_window(app: &AppHandle) {
+    // Tray/menu callbacks can also deadlock WebView2 when they construct a
+    // window synchronously. Serialize creation on a blocking worker instead.
+    let app = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        static CREATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = CREATE.lock().unwrap_or_else(|e| e.into_inner());
+        open_settings_window_inner(&app);
+    });
+}
+
+fn open_settings_window_inner(app: &AppHandle) {
+    if !crate::lock::is_unlocked(app) {
+        crate::lock::show_lock_window(app);
+        return;
+    }
     if let Some(w) = app.get_webview_window("settings") {
         let _ = w.show();
         let _ = w.set_focus();
         return;
     }
-    let _ = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("index.html".into()))
+    match WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("index.html".into()))
         .title("whatRust — Settings")
         .inner_size(440.0, 680.0)
-        .resizable(false)
-        .build();
+        .min_inner_size(440.0, 520.0)
+        .resizable(true)
+        .visible(false)
+        .build()
+    {
+        Ok(w) if crate::lock::is_unlocked(app) => {
+            let _ = w.show();
+            let _ = w.set_focus();
+        }
+        Ok(_) => crate::lock::show_lock_window(app),
+        Err(e) => crate::dlog::log(&format!("settings window creation failed: {e}")),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

On Windows, the remote WhatsApp Web context could call neither whatRust's custom notification commands nor Settings commands because its capability granted only the notification plugin's default permission. The bridge swallowed the resulting ACL rejection, so audio could play while toast notifications, unread state, and the notification sender registration flow failed silently.

The multi-account flow also created WebView windows synchronously from IPC commands, which can deadlock WebView2. There was no persisted startup-account choice. In Settings, native select options could become white text on a white menu, and saving while autostart was disabled attempted to remove a non-existent launcher entry.

## Changes

- Add explicit Tauri permissions for the WhatsApp bridge, Settings, and lock windows; assign them to their matching capabilities.
- Surface bridge IPC failures to the local diagnostic log without message contents and cover notification/unread routing with Node tests.
- Serialize account mutations and create account/Settings/lock WebViews on a blocking worker to avoid the WebView2 deadlock.
- Persist a validated default account and open it first at startup while the other account windows remain connected in the background.
- Make disabled autostart saves idempotent and define option foreground/background colors for both system themes.

## Validation

- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet` (78 tests)
- `node --test src-tauri/resources/notifications.test.mjs` (4 tests)
- `tauri build --bundles nsis --ci`
- Manual Windows 11 / WebView2 validation from the NSIS installer: notification sender registration, startup default account, Settings save with autostart off, and native select colors in dark and light themes.

Related to #3.
